### PR TITLE
Added a minimal JIT functionallity

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,7 +105,7 @@ if (LLVM_FOUND)
     add_definitions(${LLVM_DEFINITIONS})
     # target_include_directories(${OBERON_LANG} PRIVATE ${LLVM_INCLUDE_DIRS})
     include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-    llvm_map_components_to_libnames(llvm_libs core support passes ${LLVM_TARGETS_TO_BUILD})
+    llvm_map_components_to_libnames(llvm_libs core executionengine jitlink orcjit nativecodegen support passes ${LLVM_TARGETS_TO_BUILD})
     target_link_libraries(${OBERON_LANG} PRIVATE ${llvm_libs})
 endif ()
 

--- a/src/codegen/CodeGen.h
+++ b/src/codegen/CodeGen.h
@@ -21,7 +21,7 @@ public:
     virtual void configure(CompilerFlags *flags) = 0;
 
     virtual void generate(Node *ast, boost::filesystem::path path) = 0;
-    virtual void jit(Node *ast, boost::filesystem::path path) = 0;
+    virtual int jit(Node *ast, boost::filesystem::path path) = 0;
 };
 
 

--- a/src/codegen/CodeGen.h
+++ b/src/codegen/CodeGen.h
@@ -21,7 +21,7 @@ public:
     virtual void configure(CompilerFlags *flags) = 0;
 
     virtual void generate(Node *ast, boost::filesystem::path path) = 0;
-
+    virtual void jit(Node *ast, boost::filesystem::path path) = 0;
 };
 
 

--- a/src/codegen/llvm/LLVMCodeGen.h
+++ b/src/codegen/llvm/LLVMCodeGen.h
@@ -17,6 +17,8 @@
 
 // using namespace llvm;
 
+int mingw_noop_main(void);
+
 class LLVMCodeGen final : public CodeGen {
 
 private:
@@ -38,7 +40,7 @@ public:
     void configure(CompilerFlags *flags) final;
 
     void generate(Node *ast, boost::filesystem::path path) final;
-
+    void jit(Node *ast, boost::filesystem::path path) final;
 };
 
 

--- a/src/codegen/llvm/LLVMCodeGen.h
+++ b/src/codegen/llvm/LLVMCodeGen.h
@@ -40,7 +40,7 @@ public:
     void configure(CompilerFlags *flags) final;
 
     void generate(Node *ast, boost::filesystem::path path) final;
-    void jit(Node *ast, boost::filesystem::path path) final;
+    int jit(Node *ast, boost::filesystem::path path) final;
 };
 
 

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -35,7 +35,8 @@ void Compiler::compile(boost::filesystem::path file) {
             auto printer = std::make_unique<NodePrettyPrinter>(std::cout);
             printer->print(ast.get());
 #endif
-            codegen_->generate(ast.get(), fp.string());
+            //codegen_->generate(ast.get(), fp.string());
+            codegen_->jit(ast.get(), fp.string());
         }
 
     }

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -35,9 +35,39 @@ void Compiler::compile(boost::filesystem::path file) {
             auto printer = std::make_unique<NodePrettyPrinter>(std::cout);
             printer->print(ast.get());
 #endif
-            //codegen_->generate(ast.get(), fp.string());
-            codegen_->jit(ast.get(), fp.string());
+            codegen_->generate(ast.get(), fp.string());
         }
 
     }
+}
+
+int Compiler::jit(boost::filesystem::path file) {
+    // Scan and parse the input file
+    logger_->debug(PROJECT_NAME, "parsing...");
+    auto fp = absolute(file);
+    auto errors = logger_->getErrorCount();
+    auto system = std::make_unique<Oberon07>();
+    auto scanner = std::make_unique<Scanner>(fp.string(), logger_);
+    auto parser = std::make_unique<Parser>(scanner.get(), logger_);
+    auto ast = parser->parse();
+    if (ast && ast->getNodeType() == NodeType::module) {
+        // Run the analyzer
+        logger_->debug(PROJECT_NAME, "analyzing...");
+        auto analyzer = std::make_unique<Analyzer>(logger_);
+        auto path = fp.parent_path();
+        auto importer = std::make_unique<SymbolImporter>(logger_, flags_, path);
+        auto exporter = std::make_unique<SymbolExporter>(logger_, path);
+        analyzer->add(std::make_unique<SemanticAnalysis>(system->getSymbolTable(), importer.get(), exporter.get()));
+        analyzer->add(std::make_unique<LambdaLifter>());
+        analyzer->run(ast.get());
+        if (logger_->getErrorCount() == errors) {
+#ifdef _DEBUG
+            auto printer = std::make_unique<NodePrettyPrinter>(std::cout);
+            printer->print(ast.get());
+#endif
+            return codegen_->jit(ast.get(), fp.string());
+        }
+
+    }
+    return 1;
 }

--- a/src/compiler/Compiler.h
+++ b/src/compiler/Compiler.h
@@ -24,7 +24,7 @@ public:
     ~Compiler() = default;
 
     void compile(boost::filesystem::path file);
-
+    int jit(boost::filesystem::path file);
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,7 @@ int main(const int argc, const char **argv) {
             ("filetype", po::value<std::string>()->value_name("<type>"), "Set type of output file. [asm, bc, obj, ll]")
             ("reloc", po::value<std::string>()->value_name("<model>"), "Set relocation model. [default, static, pic]")
             ("target", po::value<std::string>()->value_name("<triple>"), "Target triple for cross compilation.")
+            ("run,r", "Run with LLVM JIT.")
             ("quiet,q", "Suppress all compiler outputs.");
     auto hidden = po::options_description("HIDDEN");
     hidden.add_options()


### PR DESCRIPTION
I believe this could be usable as a test tool and also to run Oberon modules
as scripts from the command line.

This is based on the lli tool in the llvm project folder and heavy simplified.

It works fine with simple test modules.

To be more usable we should support:
- loading of extra dynamic libraries, static libraries or objects.
- possibility to invoke a given module procedure without parameters.
- pass arguments from the command line.

Issues:
- Symbols should not be exported.

Now as I understand it resolves symbols from the current process and therefore picks up at least printf correctly.

Again this could probably be integrated more elegantly. Now it
has some code duplication and some non-ideal work arounds commented
in the code.
