### PR TITLE
Fix building liboberon on MSYS2 with CLANG

### DIFF
--- a/liboberon/Makefile
+++ b/liboberon/Makefile
@@ -17,14 +17,26 @@ endif
 # TGT = x86_64-linux-gnu
 LIB = ../test/oberon/lib
 INC = ../test/oberon/include
-O7C = ../cmake-build-release/src/oberon-lang
-O7CFLAGS = -q -O3 --reloc=pic -fenable-extern -fenable-varargs # --target $(TGT)
+ifeq ($(OS), windows)
+	O7C = ../cmake-build-release/src/oberon-lang.exe
+else
+	O7C = ../cmake-build-release/src/oberon-lang
+endif
+ifeq ($(OS), windows)
+	O7CFLAGS = -q -O3 -fenable-extern -fenable-varargs # --target $(TGT)
+else
+	O7CFLAGS = -q -O3 --reloc=pic -fenable-extern -fenable-varargs # --target $(TGT)
+endif
 LDFLAGS =
 
 # Library settings
 LIBNAME = liboberon
 
-ifeq ($(OS), macos)
+ifeq ($(OS), windows)
+	CXX = clang
+	EXT = dll
+	LDFLAGS += -shared
+else ifeq ($(OS), macos)
 	EXT = dylib
 	CXX = clang
 	LDFLAGS += -dynamiclib -install_name @rpath/$(LIBNAME).$(EXT)
@@ -59,10 +71,12 @@ dist : runtime.o Oberon.o Out.o Random.o Math.o
 
 install : dist Oberon.smb Out.smb Random.smb Math.smb
 	@echo -n Installing library...
+	@mkdir -p $(LIB)
 	@mv $(LIBNAME).$(EXT) $(LIB)
 	@mv $(LIBNAME).a $(LIB)
 	@echo ' done.'
 	@echo -n Installing symbol files...
+	@mkdir -p $(INC)
 	@mv Oberon.smb $(INC)
 	@mv Out.smb $(INC)
 	@mv Random.smb $(INC)

--- a/src/codegen/llvm/LLVMCodeGen.cpp
+++ b/src/codegen/llvm/LLVMCodeGen.cpp
@@ -141,7 +141,10 @@ void LLVMCodeGen::configure(CompilerFlags *flags) {
 
 std::string LLVMCodeGen::getLibName(const std::string &name, bool dylib, const llvm::Triple &triple) {
     std::stringstream ss;
-    if (triple.isOSWindows()) {
+    if (triple.isOSCygMing()) {
+        ss << "lib" << name;
+        ss << (dylib ? ".dll" : ".a");
+    } else if (triple.isOSWindows()) {
         ss << name << (dylib ? ".dll" : ".lib");
     } else {
         ss << "lib" << name;
@@ -236,7 +239,7 @@ void LLVMCodeGen::emit(Module *module, boost::filesystem::path path, OutputFileT
             ext = "ll";
             break;
         default:
-#if defined(_WIN32) || defined(_WIN64)
+#if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
             ext = "obj";
 #else
             ext = "o";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ int main(const int argc, const char **argv) {
         if (vm.count("verbose")) {
             logger->setLevel(LogLevel::DEBUG);
         }
-#if defined(_WIN32) || defined(_WIN64)
+#if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
         // Windows uses a semicolon to separate multiple paths
         std::string separator = ";";
 #else


### PR DESCRIPTION
Some fixes in order to build `liboberon` on MSYS2.
Work both with dynamic and static library.