### PR TITLE
Various Fixes based on Unit Tests

### DIFF
--- a/liboberon/Out.Mod
+++ b/liboberon/Out.Mod
@@ -35,10 +35,15 @@ BEGIN
     rt_out_int(val, n)
 END Long;
 
-PROCEDURE Hex*(i: LONGINT);
+PROCEDURE Hex*(x: INTEGER);
 BEGIN
-    printf("%X", i)
+    printf("%08X", x)
 END Hex;
+
+PROCEDURE LongHex*(x: LONGINT);
+BEGIN
+    printf("%016llX", x)
+END LongHex;
 
 PROCEDURE Real*(x: REAL; n: INTEGER);
 BEGIN

--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -280,7 +280,7 @@ void LLVMIRBuilder::visit(BooleanLiteralNode &node) {
 }
 
 void LLVMIRBuilder::visit(IntegerLiteralNode &node) {
-    if (node.isLong()) {
+    if (node.isLong() || node.getType()->kind() == TypeKind::LONGINT) {
         value_ = ConstantInt::getSigned(builder_.getInt64Ty(), node.value());
     } else {
         value_ = ConstantInt::getSigned(builder_.getInt32Ty(), (int) node.value());
@@ -289,7 +289,7 @@ void LLVMIRBuilder::visit(IntegerLiteralNode &node) {
 }
 
 void LLVMIRBuilder::visit(RealLiteralNode &node) {
-    if (node.isLong()) {
+    if (node.isLong() || node.getType()->kind() == TypeKind::LONGREAL) {
         value_ = ConstantFP::get(builder_.getDoubleTy(), node.value());
     } else {
         value_ = ConstantFP::get(builder_.getFloatTy(), (float) node.value());
@@ -733,7 +733,6 @@ void LLVMIRBuilder::cast(ExpressionNode &node) {
 Value *
 LLVMIRBuilder::predefinedCall(PredefinedProcedure *proc, QualIdent *ident,
                               ActualParameters *actuals, std::vector<Value *> &params) {
-    auto type = dynamic_cast<ProcedureTypeNode *>(proc->getType());
     ProcKind kind = proc->getKind();
     if (kind == ProcKind::NEW) {
         auto fun = module_->getFunction("malloc");
@@ -780,20 +779,22 @@ LLVMIRBuilder::predefinedCall(PredefinedProcedure *proc, QualIdent *ident,
             logger_.error(param->pos(), "more actual than formal parameters.");
             return value_;
         } else if (params.size() > 1) {
-            auto source = params[1]->getType();
-            auto param = actuals->parameters()[0].get();
-            if (!param->getType()->isInteger()) {
-                logger_.error(param->pos(), "type mismatch: expected integer type, found " +
-                                            to_string(param->getType()) + ".");
+            auto param0 = actuals->parameters()[0].get();
+            auto param1 = actuals->parameters()[1].get();
+            if (!param0->getType()->isInteger()) {
+                logger_.error(param0->pos(), "type mismatch: expected integer type, found " +
+                                             to_string(param0->getType()) + ".");
                 return value_;
             }
-            delta = params[1];
+            auto source = params[1]->getType();
             if (target->getIntegerBitWidth() > source->getIntegerBitWidth()) {
-                delta = builder_.CreateSExt(delta, target);
+                delta = builder_.CreateSExt(params[1], target);
             } else if (target->getIntegerBitWidth() < source->getIntegerBitWidth()) {
-                logger_.warning(param->pos(), "type mismatch: truncating " + to_string(param->getType()) + " to " +
-                                              to_string(type->parameters()[0]->getType()) + " may lose data.");
-                delta = builder_.CreateTrunc(delta, target);
+                logger_.warning(param1->pos(), "type mismatch: truncating " + to_string(param1->getType())
+                                               + " to " + to_string(param0->getType()) + " may lose data.");
+                delta = builder_.CreateTrunc(params[1], target);
+            } else {
+                delta = params[1];
             }
         } else {
             delta = ConstantInt::get(target, 1);

--- a/src/data/ast/NodePrettyPrinter.cpp
+++ b/src/data/ast/NodePrettyPrinter.cpp
@@ -191,7 +191,7 @@ void NodePrettyPrinter::selectors(std::vector<unique_ptr<Selector>> &selectors) 
 void NodePrettyPrinter::visit(ConstantDeclarationNode &node) {
     stream_ << *node.getIdentifier() << "(*" << node.getLevel() << "*) = ";
     node.getValue()->accept(*this);
-    stream_ << ';' << std::endl;
+    stream_ << "(*" << *node.getType()->getIdentifier() << "*);" << std::endl;
 }
 
 void NodePrettyPrinter::visit(FieldNode &node) {

--- a/src/sema/Sema.h
+++ b/src/sema/Sema.h
@@ -44,7 +44,7 @@ private:
     SymbolTable *symbols_;
     SymbolImporter importer_;
     SymbolExporter exporter_;
-    TypeNode *tBoolean_, *tByte_, *tChar_, *tInteger_, *tLongInt_, *tReal_, *tLongReal_, *tString_, *tSet_;
+    TypeNode *boolTy_, *byteTy, *charTy, *integerTy_, *longIntTy_, *realTy_, *longRealTy_, *stringTy_, *setTy_, *nullTy_;
 
     bool assertEqual(Ident *, Ident *) const;
     void assertUnique(IdentDef *, DeclarationNode *);

--- a/test/oberon/Predefines.Mod
+++ b/test/oberon/Predefines.Mod
@@ -8,16 +8,22 @@ VAR i: INTEGER;
     l: LONGINT;
     a: ARRAY 10 OF INTEGER;
     r: RECORD x: INTEGER END;
-    p: POINTER TO LONGINT;
+    p: POINTER TO RECORD x: INTEGER END;
 BEGIN
     i := 0;
     l := 0;
-    INC(a[0], p^);
     INC(l);
     Out.String("["); Out.Int(i, 0); Out.String(","); Out.Long(l, 0); Out.String("]"); Out.Ln;
     DEC(i, 5);
     DEC(l);
-    Out.String("["); Out.Int(i, 0); Out.String(","); Out.Long(l, 0); Out.String("]"); Out.Ln
+    Out.String("["); Out.Int(i, 0); Out.String(","); Out.Long(l, 0); Out.String("]"); Out.Ln;
+    INC(i, i);
+    INC(i, l); (* should trigger a warning *)
+    INC(l, i);
+    INC(l, l);
+    INC(a[0]);
+    INC(r.x);
+    INC(p.x)
 END IncDec;
 
 PROCEDURE NewFree;

--- a/test/unittests/codegen/arithmetic_13.mod
+++ b/test/unittests/codegen/arithmetic_13.mod
@@ -12,7 +12,7 @@ BEGIN
   a := -7.5;
   b := 15.0;
   c := (a + b) / 2.0;
-  Out.Real(c); Out.Ln
+  Out.Real(c, 10); Out.Ln
 END Test;
 
 BEGIN

--- a/test/unittests/codegen/arithmetic_14.mod
+++ b/test/unittests/codegen/arithmetic_14.mod
@@ -12,7 +12,7 @@ BEGIN
   a := 7.5;
   b := 15.0;
   c := (a - b) / 2.0;
-  Out.Real(c); Out.Ln
+  Out.Real(c, 10); Out.Ln
 END Test;
 
 BEGIN

--- a/test/unittests/codegen/arithmetic_16.mod
+++ b/test/unittests/codegen/arithmetic_16.mod
@@ -12,22 +12,22 @@ BEGIN
   a := -7.5;
   b := 3.5;
   c := a * b;
-  Out.Real(c); Out.Ln;
+  Out.Real(c, 10); Out.Ln;
   a := 7.5;
   b := 0;
   c := a * b;
-  Out.Real(c); Out.Ln;
+  Out.Real(c, 10); Out.Ln;
   a := 7.5;
   b := 3.5;
   c := a * b;
-  Out.Real(c); Out.Ln
+  Out.Real(c, 10); Out.Ln
 END Test;
 
 BEGIN
     Test
 END Arithmetic16.
 (*
-    CHECK: -26.25
+    CHECK: -2.63E+01
     CHECK: 0
-    CHECK: 26.25
+    CHECK: 2.63E+01
 *)

--- a/test/unittests/codegen/array_2.mod
+++ b/test/unittests/codegen/array_2.mod
@@ -13,9 +13,9 @@ BEGIN
   FOR i := 0 TO 2 DO
     a[i] := i + 1.5
   END;
-  Out.Real(a[0]); Out.Ln;
-  Out.Real(a[1]); Out.Ln;
-  Out.Real(a[2]); Out.Ln
+  Out.Real(a[0], 10); Out.Ln;
+  Out.Real(a[1], 10); Out.Ln;
+  Out.Real(a[2], 10); Out.Ln
 END Test;
 
 BEGIN

--- a/test/unittests/codegen/array_5.mod
+++ b/test/unittests/codegen/array_5.mod
@@ -24,7 +24,7 @@ END Test;
 
 BEGIN
     Test
-END Array4.
+END Array5.
 (*
     CHECK: 1
     CHECK: 1

--- a/test/unittests/codegen/const_1.mod
+++ b/test/unittests/codegen/const_1.mod
@@ -32,5 +32,5 @@ END Const1.
     CHECK: '
     CHECK: Oberon
     CHECK: 'Oberon'
-    CHECK: 12.3
+    CHECK: 1.2E+01
 *)

--- a/test/unittests/codegen/const_long_hex.mod
+++ b/test/unittests/codegen/const_long_hex.mod
@@ -1,23 +1,22 @@
 (*
-  RUN: %oberon -fenable-extern -fenable-varargs --run %s | filecheck %s
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
   64bit hex constants not correctly parsed
   Is there need to mark constant as 64bit like C/C++?
   Maybe LONG(00H)?
 *)
 MODULE ConstLongHex;
+IMPORT Out;
 
 CONST
   hexmax = 0FFFFFFFFFFFFFFFFH;
   hexdbg = 0DEADBEEFDEADBEEFH;
   hexmin = 08000000000000000H;
 
-PROCEDURE printf(format: STRING; ...): INTEGER; EXTERN;
-
 PROCEDURE Test;
 BEGIN
-  printf("%llX\n", hexmax);
-  printf("%llX\n", hexdbg);
-  printf("%llX\n", hexmin)
+  Out.LongHex(hexmax); Out.Ln;
+  Out.LongHex(hexdbg); Out.Ln;
+  Out.LongHex(hexmin); Out.Ln
 END Test;
 
 BEGIN

--- a/test/unittests/codegen/const_longint.mod
+++ b/test/unittests/codegen/const_longint.mod
@@ -14,8 +14,8 @@ CONST
 
 PROCEDURE Test;
 BEGIN
-  Out.Int(longintmax, 0); Out.Ln;
-  Out.Int(longintmin, 0); Out.Ln
+  Out.Long(longintmax, 0); Out.Ln;
+  Out.Long(longintmin, 0); Out.Ln
 END Test;
 
 BEGIN

--- a/test/unittests/codegen/const_longreal_1.mod
+++ b/test/unittests/codegen/const_longreal_1.mod
@@ -6,8 +6,8 @@
 MODULE ConstLongReal1;
 
 CONST
-  min = -1.7976931348623158D308
-  max = -2.2250738585072014D-308
+  min = -1.7976931348623158E308;
+  max = -2.2250738585072014E-308;
 
 PROCEDURE printf(format: STRING; ...): INTEGER; EXTERN;
 
@@ -16,15 +16,15 @@ VAR
   val : LONGREAL;
 BEGIN
   val := min;
-  printf("%.9g\n", val);
+  printf("%.16g\n", val);
   val := max;
-  printf("%.9g\n", val)
+  printf("%.16g\n", val)
 END Test;
 
 BEGIN
     Test()
 END ConstLongReal1.
 (*
-    CHECK: -1.7976931348623158e308
-    CHECK: -2.2250738585072014e-308
+    CHECK: -1.797693134862316e+308
+    CHECK: -2.225073858507201e-308
 *)

--- a/test/unittests/codegen/const_real_1.mod
+++ b/test/unittests/codegen/const_real_1.mod
@@ -7,23 +7,23 @@ MODULE ConstReal1;
 IMPORT Out;
 
 CONST
-  min = 1.1754939E-38;
-  max = 3.4028235E38;
+  min = 1.175494351E-38;
+  max = 3.402823466E+38;
 
 PROCEDURE Test;
 VAR
   rval : REAL;
 BEGIN
   rval := min;
-  Out.Real(rval); Out.Ln;
+  Out.Real(rval, 16); Out.Ln;
   rval := max;
-  Out.Real(rval); Out.Ln
+  Out.Real(rval, 16); Out.Ln
 END Test;
 
 BEGIN
     Test()
 END ConstReal1.
 (*
-    CHECK: 1.17549393e-038
-    CHECK: 3.4028235e038
+    CHECK: 0.11754944E-37
+    CHECK: 3.40282368E+38
 *)

--- a/test/unittests/codegen/const_set.mod
+++ b/test/unittests/codegen/const_set.mod
@@ -1,18 +1,17 @@
 (*
-  RUN: %oberon -fenable-extern -fenable-varargs --run %s | filecheck %s
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
   SET type not supported yet
 *)
 MODULE ConstSet;
+IMPORT Out;
 
 CONST
   WordSize = 32;
-  all = {0 .. WordSize-1}
-
-PROCEDURE printf(format: STRING; ...): INTEGER; EXTERN;
+  all = {0 .. WordSize-1};
 
 PROCEDURE Test;
 BEGIN
-    printf("%X\n", ORD(all))
+    Out.Hex(ORD(all)); Out.Ln
 END Test;
 
 BEGIN

--- a/test/unittests/codegen/procedure_5.mod
+++ b/test/unittests/codegen/procedure_5.mod
@@ -9,11 +9,15 @@ IMPORT Out;
 VAR
   a, b, c : INTEGER;
 
-PROCEDURE Test : INTEGER;
-    PROCEDURE Inner : INTEGER;
-    BEGIN c := a + b
+PROCEDURE Test();
+
+    PROCEDURE Inner();
+    BEGIN
+        c := a + b
     END Inner;
-BEGIN Inner()
+
+BEGIN
+    Inner()
 END Test;
 
 BEGIN


### PR DESCRIPTION
This pull request updates `oberon-lang` to make more of the unit tests pass. The tests that still fail are mainly due to, as of now, unsupported functionality.

> Testing Time: 0.26s
>   Unsupported        : 13
>   Passed             : 50
>   Expectedly Failed  :  8
>   Failed             :  8
>   Unexpectedly Passed:  1

The following test cases fail.

- **Oberon :: codegen/arithmetic_12.mod**: type `BYTE` not yet supported
- **Oberon :: codegen/array_5.mod**: `PROCEDURE` types not yet supported
- **Oberon :: codegen/const_integer.mod**: problem in test: type mismatch
- **Oberon :: codegen/loop_2.mod**: `LOOP` statement not yet supported
- **Oberon :: codegen/relations_6.mod**: hexadecimal `CHAR` values are not supported yet
- **Oberon :: codegen/relations_7.mod**: `CHAR` comparisons are not supported yet
- **Oberon :: parser/fail_on_extra_semicolon.mod**: this is intended behaviour
- **Oberon :: parser/procedure_empty.mod**: this is intended behaviour