### PR TITLE
System pseudo module [DRAFT]

### DIFF
--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -196,6 +196,9 @@ void LLVMIRBuilder::arrayInitializers(TypeNode *base, TypeNode *type, vector<Val
 
 void LLVMIRBuilder::visit(ImportNode &node) {
     std::string name = node.getModule()->name();
+    if (name == "SYSTEM") {
+        return; /* no initialization for pseudo modules */
+    }
     auto type = FunctionType::get(builder_.getInt32Ty(), {});
     auto fun = module_->getOrInsertFunction(name, type);
     if (fun) {
@@ -844,6 +847,14 @@ LLVMIRBuilder::createPredefinedCall(PredefinedProcedure *proc, QualIdent *ident,
             return createExclCall(params[0], params[1]);
         case ProcKind::ORD:
             return createOrdCall(actuals[0].get(), params[0]);
+        case ProcKind::SYSTEM_ADR:
+            return createSystemAdrCall(actuals, params);
+        case ProcKind::SYSTEM_GET:
+            return createSystemGetCall(actuals, params);
+        case ProcKind::SYSTEM_PUT:
+            return createSystemPutCall(actuals, params);
+        case ProcKind::SYSTEM_COPY:
+            return createSystemCopyCall(params[0], params[1], params[2]);
         default:
             logger_.error(ident->start(), "unsupported predefined procedure: " + to_string(*ident) + ".");
             // to generate correct LLVM IR, the current value is returned (no-op).
@@ -993,7 +1004,7 @@ LLVMIRBuilder::createLenCall(vector<unique_ptr<ExpressionNode>> &actuals, std::v
                 logger_.error(param1->pos(), "array dimension cannot be a negative value.");
                 return value_;
             }
-            if (value >= arrayTy->dimensions()) {
+            if (value >= (long)arrayTy->dimensions()) {
                 logger_.error(param1->pos(), "value exceeds number of array dimensions.");
                 return value_;
             }
@@ -1098,6 +1109,57 @@ LLVMIRBuilder::createRorCall(llvm::Value *param, llvm::Value *shift) {
     Value *delta = builder_.CreateSub(builder_.getInt64(64), shift);
     Value *rhs = builder_.CreateShl(param, delta);
     return builder_.CreateOr(lhs, rhs);
+}
+
+Value *
+LLVMIRBuilder::createSystemAdrCall(vector<unique_ptr<ExpressionNode>> &actuals, std::vector<Value *> &params) {
+    // TODO : Support other types
+    auto param = actuals[0].get();
+    auto type = param->getType();
+    if (!type->isNumeric()) {
+        logger_.error(param->pos(), "expected numeric type");
+        return value_;
+    }
+    return builder_.CreatePtrToInt(params[0], builder_.getInt64Ty());
+}
+
+Value *
+LLVMIRBuilder::createSystemGetCall(vector<unique_ptr<ExpressionNode>> &actuals, std::vector<Value *> &params) {
+    // TODO : Support other types
+    auto param = actuals[1].get();
+    auto type = param->getType();
+    if (!type->isNumeric()) {
+        logger_.error(param->pos(), "expected numeric type");
+        return value_;
+    }
+    auto base = getLLVMType(type);
+    auto ptrtype = PointerType::get(base, 0);
+    auto ptr = builder_.CreateIntToPtr(params[0], ptrtype);
+    auto value = builder_.CreateLoad(base, ptr, true);
+    return builder_.CreateStore(value, params[1]);
+}
+
+Value *
+LLVMIRBuilder::createSystemPutCall(vector<unique_ptr<ExpressionNode>> &actuals, std::vector<Value *> &params) {
+    // TODO : Support other types
+    auto param = actuals[1].get();
+    auto type = param->getType();
+    if (!type->isNumeric()) {
+        logger_.error(param->pos(), "expected numeric type");
+        return value_;
+    }
+    auto base = getLLVMType(type);
+    auto ptrtype = PointerType::get(base, 0);
+    auto ptr = builder_.CreateIntToPtr(params[0], ptrtype);
+    return builder_.CreateStore(params[1], ptr, true);
+}
+
+Value *
+LLVMIRBuilder::createSystemCopyCall(llvm::Value *src, llvm::Value *dst, llvm::Value *n) {
+    auto ptrtype = builder_.getPtrTy();
+    auto srcptr = builder_.CreateIntToPtr(src, ptrtype);
+    auto dstptr = builder_.CreateIntToPtr(dst, ptrtype);
+    return builder_.CreateMemCpy(dstptr, MaybeAlign(), srcptr, MaybeAlign(), n, true);
 }
 
 Value *

--- a/src/codegen/llvm/LLVMIRBuilder.h
+++ b/src/codegen/llvm/LLVMIRBuilder.h
@@ -92,8 +92,13 @@ private:
     Value *createOrdCall(ExpressionNode *, Value *);
     Value *createRolCall(Value *, Value *);
     Value *createRorCall(Value *, Value *);
+    
+    Value *createSystemAdrCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
+    Value *createSystemGetCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
+    Value *createSystemPutCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
+    Value *createSystemCopyCall(Value *, Value *, Value *);
+    
     Value *createTrapCall(unsigned);
-
     Value *createInBoundsCheck(Value *, Value *, Value *);
 
     void visit(ModuleNode &) override;

--- a/src/data/symtab/SymbolTable.cpp
+++ b/src/data/symtab/SymbolTable.cpp
@@ -168,5 +168,9 @@ void SymbolTable::closeScope() {
 }
 
 unsigned int SymbolTable::getLevel() const {
-    return scope_->getLevel();
+    if (scope_ == nullptr) {
+        return GLOBAL_LEVEL;
+    } else {
+        return scope_->getLevel();
+    }
 }

--- a/src/sema/Sema.cpp
+++ b/src/sema/Sema.cpp
@@ -86,10 +86,18 @@ Sema::onImport(const FilePos &start, [[maybe_unused]] const FilePos &end,
     auto node = make_unique<ImportNode>(start, std::move(alias), std::move(ident));
     // TODO check duplicate imports
     std::unique_ptr<ModuleNode> module;
-    if (node->getAlias()) {
-        module = importer_.read(node->getAlias()->name(), node->getModule()->name(), symbols_);
+    auto name = node->getModule()->name();
+    if (name == "SYSTEM") {
+        module = std::make_unique<ModuleNode>(std::make_unique<Ident>(name));
+        if (node->getAlias()) {
+            module->setAlias(node->getAlias()->name());
+        }
     } else {
-        module = importer_.read(node->getModule()->name(), symbols_);
+        if (node->getAlias()) {
+            module = importer_.read(node->getAlias()->name(), name, symbols_);
+        } else {
+            module = importer_.read(name, symbols_);
+        }
     }
     if (module) {
         context_->addExternalModule(std::move(module));

--- a/src/system/OberonSystem.h
+++ b/src/system/OberonSystem.h
@@ -17,6 +17,7 @@ private:
     std::vector<std::unique_ptr<DeclarationNode>> decls_;
     std::vector<std::unique_ptr<TypeNode>> types_;
     std::unordered_map<std::string, BasicTypeNode *> baseTypes_;
+    std::string module_;
 
     TypeDeclarationNode *createTypeDeclaration(TypeNode *);
 
@@ -27,6 +28,9 @@ protected:
 public:
     explicit OberonSystem() : symbols_(), decls_(), types_(), baseTypes_() {};
     virtual ~OberonSystem();
+    
+    void createNamespace(const std::string &module);
+    void leaveNamespace();
 
     void createBasicTypes(const std::vector<std::pair<std::pair<TypeKind, unsigned int>, bool>>& types);
     BasicTypeNode *createBasicType(TypeKind kind, unsigned int size);

--- a/src/system/PredefinedProcedure.h
+++ b/src/system/PredefinedProcedure.h
@@ -21,7 +21,8 @@ using std::vector;
 
 enum class ProcKind {
     ABS, ASH, ASR, ASSERT, CAP, CHR, COPY, DEC, ENTIER, EXCL, FLOOR, FLT, FREE, HALT, INC, INCL, LEN, LONG, LSL,
-    MAX, MIN, NEW, ODD, ORD, PACK, ROL, ROR, SHORT, SIZE, UNPK
+    MAX, MIN, NEW, ODD, ORD, PACK, ROL, ROR, SHORT, SIZE, UNPK,
+    SYSTEM_ADR, SYSTEM_GET, SYSTEM_PUT, SYSTEM_SIZE, SYSTEM_BIT, SYSTEM_COPY, SYSTEM_VAL
 };
 
 class PredefinedProcedure final : public ProcedureNode {

--- a/test/unittests/codegen/system_1.mod
+++ b/test/unittests/codegen/system_1.mod
@@ -1,0 +1,26 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE System1;
+
+IMPORT SYSTEM, Out;
+
+PROCEDURE Test;
+VAR 
+    xadr, yadr : LONGINT;
+    x, y, z : INTEGER;
+BEGIN
+    x := 3; y := -3;
+    xadr := SYSTEM.ADR(x);
+    yadr := SYSTEM.ADR(y);
+    SYSTEM.GET(xadr, z);
+    SYSTEM.PUT(yadr, z);
+    Out.Int(y, 0); Out.Ln
+END Test;
+
+BEGIN
+    Test
+END System1.
+(*
+    CHECK: 3
+*)

--- a/test/unittests/codegen/system_2.mod
+++ b/test/unittests/codegen/system_2.mod
@@ -1,0 +1,31 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE System2;
+
+IMPORT SYSTEM, Out;
+
+PROCEDURE Test;
+VAR 
+    xadr, yadr : LONGINT;
+    x, y : ARRAY 4 OF INTEGER;
+    i : INTEGER;
+BEGIN
+    FOR i := 0 TO 3 DO x[i] := (i + 1) END;
+    FOR i := 0 TO 3 DO y[i] := -(i + 1) END;
+    xadr := SYSTEM.ADR(x[0]);
+    yadr := SYSTEM.ADR(y[0]);
+    (* TODO : SYSTEM.COPY(xadr, yadr, LEN(x) * SYSTEM.SIZE(INTEGER)); *)
+    SYSTEM.COPY(xadr, yadr, 4 * 4);
+    FOR i := 0 TO 3 DO Out.Int(y[i], 0); Out.Ln END
+END Test;
+
+BEGIN
+    Test
+END System2.
+(*
+    CHECK: 1
+    CHECK: 2
+    CHECK: 3
+    CHECK: 4
+*)


### PR DESCRIPTION
Minimal implementation of the SYSTEM module described in the Oberon-07 language report.

(NOTE : This used to work OK, until the last changes with removal of the STRING type.)

SYSTEM.ADR, SYSTEM.GET, SYSTEM.PUT and SYSTEM.COPY currently implemented.
SYSTEM.VAL I am not sure is possible to implement currently due to the TYPE argument expected.
Same for the pervasive procedures MIN & MAX.

This is marked [DRAFT] as I suspect this could be integrated in a better way.

