### PR TITLE
Add flag to set directory for generated .smb files

### DIFF
--- a/src/compiler/CompilerConfig.cpp
+++ b/src/compiler/CompilerConfig.cpp
@@ -17,6 +17,14 @@ string CompilerConfig::getOutputFile() const {
     return outfile_;
 }
 
+void CompilerConfig::setSymDir(const string &dir) {
+    symdir_ = dir;
+}
+
+string CompilerConfig::getSymDir() const {
+    return symdir_;
+}
+
 void CompilerConfig::setTargetTriple(const string &target) {
     target_ = target;
 }

--- a/src/compiler/CompilerConfig.h
+++ b/src/compiler/CompilerConfig.h
@@ -43,6 +43,7 @@ private:
     vector<path> infiles_;
     string outfile_;
     string target_;
+    string symdir_;
     OutputFileType type_;
     OptimizationLevel level_;
     RelocationModel model_;
@@ -56,7 +57,7 @@ private:
 
 public:
     CompilerConfig() : logger_(LogLevel::INFO, cout),
-            infiles_(), outfile_(), target_(), type_(OutputFileType::ObjectFile), level_(OptimizationLevel::O0),
+            infiles_(), outfile_(), target_(), symdir_(), type_(OutputFileType::ObjectFile), level_(OptimizationLevel::O0),
             model_(RelocationModel::DEFAULT), incpaths_(), libpaths_(), libs_(), flags_(0), jit_(false) {
 #ifdef _DEBUG
         logger_.setLevel(LogLevel::DEBUG);
@@ -74,6 +75,9 @@ public:
     void setOutputFile(const string &file);
     [[nodiscard]] string getOutputFile() const;
 
+    void setSymDir(const string &dir);
+    [[nodiscard]] string getSymDir() const;
+    
     void setTargetTriple(const string &target);
     [[nodiscard]] string getTargetTriple() const;
 

--- a/src/data/symtab/SymbolExporter.cpp
+++ b/src/data/symtab/SymbolExporter.cpp
@@ -4,10 +4,18 @@
 
 #include "SymbolExporter.h"
 
+using std::filesystem::path;
+
 void SymbolExporter::write(const std::string &name, SymbolTable *symbols) {
     ref_ = ((int) TypeKind::STRING) + 1;
-    auto path = context_->getSourceFileName().parent_path();
-    auto fp = (path / name).replace_extension(".smb");
+    path pth;
+    auto symdir = config_.getSymDir();
+    if (symdir == "") {
+        pth = context_->getSourceFileName().parent_path();
+    } else {
+        pth = symdir;
+    }
+    auto fp = (pth / name).replace_extension(".smb");
     auto file = std::make_unique<SymbolFile>();
     file->open(fp.string(), std::ios::out);
     // write symbol file header

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@ int main(const int argc, const char **argv) {
             (",f", po::value<vector<string>>()->value_name("<flag>"), "Compiler configuration flags.")
             (",O", po::value<int>()->value_name("<level>"), "Optimization level. [O0, O1, O2, O3]")
             (",o", po::value<string>()->value_name("<filename>"), "Name of the output file.")
+            ("sym-dir", po::value<string>()->value_name("<directory>"), "Set output path for generated .smb files.")
             ("filetype", po::value<string>()->value_name("<type>"), "Set type of output file. [asm, bc, obj, ll]")
             ("reloc", po::value<string>()->value_name("<model>"), "Set relocation model. [default, static, pic]")
             ("target", po::value<string>()->value_name("<triple>"), "Target triple for cross compilation.")
@@ -199,6 +200,13 @@ int main(const int argc, const char **argv) {
         }
         if (vm.count("-o")) {
             config.setOutputFile(vm["-o"].as<string>());
+        }
+        if (vm.count("sym-dir")) {
+            config.setSymDir(vm["sym-dir"].as<string>());
+            auto path = std::filesystem::path(config.getSymDir());
+            if (!std::filesystem::is_directory(path)) {
+                logger.error(PROJECT_NAME, "sym-dir path not valid");
+            }
         }
         if (vm.count("target")) {
             if (config.isJit()) {


### PR DESCRIPTION
This change adds a new flag to set the folder where generated .smb files are placed.
I think this should be separate from the output file argument.
Looked at Clang here and named flag as '--sym-dir'.
