### PR TITLE
Update to SYSTEM.ADR and SYSTEM.COPY

### DIFF
--- a/src/system/OberonSystem.cpp
+++ b/src/system/OberonSystem.cpp
@@ -142,13 +142,13 @@ void Oberon07::initSymbolTable(SymbolTable *symbols) {
     this->createProcedure(ProcKind::EXCL, "EXCL", {{setType, true}, {intType, false}}, nullptr, false, true);
     this->createProcedure(ProcKind::ORD, "ORD", {{anyType, false}}, intType, false, true);
     this->createProcedure(ProcKind::CHR, "CHR", {{intType, false}}, charType, false, true);
-    this->createProcedure(ProcKind::SIZE, "SIZE", {{typeType, false}}, intType, false, true);
+    this->createProcedure(ProcKind::SIZE, "SIZE", {{typeType, false}}, longType, false, true);
 
     createNamespace("SYSTEM");
     this->createProcedure(ProcKind::SYSTEM_ADR, "ADR", {{anyType, true}}, longType, false, true);
     this->createProcedure(ProcKind::SYSTEM_GET, "GET", {{longType, false}, {anyType, true}}, nullptr, false, true);
     this->createProcedure(ProcKind::SYSTEM_PUT, "PUT", {{longType, false}, {anyType, false}}, nullptr, false, true);
-    this->createProcedure(ProcKind::SYSTEM_COPY, "COPY", {{longType, false}, {longType, false}, {longType, false}}, nullptr, false, true);
-    this->createProcedure(ProcKind::SYSTEM_SIZE, "SIZE", {{typeType, false}}, intType, false, true);
+    this->createProcedure(ProcKind::SYSTEM_COPY, "COPY", {{longType, false}, {longType, false}, {intType, false}}, nullptr, false, true);
+    this->createProcedure(ProcKind::SYSTEM_SIZE, "SIZE", {{typeType, false}}, longType, false, true);
     leaveNamespace();
 }

--- a/test/unittests/codegen/system_1.mod
+++ b/test/unittests/codegen/system_1.mod
@@ -7,15 +7,32 @@ IMPORT SYSTEM, Out;
 
 PROCEDURE Test;
 VAR 
-    xadr, yadr : LONGINT;
+    adr1, adr2 : LONGINT;
     x, y, z : INTEGER;
+    a, b, c : CHAR;
+    d, e, f : BOOLEAN;
 BEGIN
+    (* INTEGER *)
     x := 3; y := -3;
-    xadr := SYSTEM.ADR(x);
-    yadr := SYSTEM.ADR(y);
-    SYSTEM.GET(xadr, z);
-    SYSTEM.PUT(yadr, z);
-    Out.Int(y, 0); Out.Ln
+    adr1 := SYSTEM.ADR(x);
+    adr2 := SYSTEM.ADR(y);
+    SYSTEM.GET(adr1, z);
+    SYSTEM.PUT(adr2, z);
+    Out.Int(y, 0); Out.Ln;
+    (* CHAR *)
+    a := "a"; b := "b";
+    adr1 := SYSTEM.ADR(a);
+    adr2 := SYSTEM.ADR(b);
+    SYSTEM.GET(adr1, c);
+    SYSTEM.PUT(adr2, c);
+    Out.Char(b); Out.Ln;
+    (* BOOLEAN *)
+    d := FALSE; e := TRUE;
+    adr1 := SYSTEM.ADR(d);
+    adr2 := SYSTEM.ADR(e);
+    SYSTEM.GET(adr1, f);
+    SYSTEM.PUT(adr2, f);
+    Out.Int(ORD(e), 0); Out.Ln
 END Test;
 
 BEGIN
@@ -23,4 +40,6 @@ BEGIN
 END System1.
 (*
     CHECK: 3
+    CHECK: a
+    CHECK: 0
 *)

--- a/test/unittests/codegen/system_3.mod
+++ b/test/unittests/codegen/system_3.mod
@@ -1,7 +1,7 @@
 (*
   RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
 *)
-MODULE System2;
+MODULE System3;
 
 IMPORT SYSTEM, Out;
 
@@ -13,15 +13,15 @@ VAR
 BEGIN
     FOR i := 0 TO 3 DO x[i] := (i + 1) END;
     FOR i := 0 TO 3 DO y[i] := -(i + 1) END;
-    xadr := SYSTEM.ADR(x[0]);
-    yadr := SYSTEM.ADR(y[0]);
+    xadr := SYSTEM.ADR(x);
+    yadr := SYSTEM.ADR(y);
     SYSTEM.COPY(xadr, yadr, LEN(x));
     FOR i := 0 TO 3 DO Out.Int(y[i], 0); Out.Ln END
 END Test;
 
 BEGIN
     Test
-END System2.
+END System3.
 (*
     CHECK: 1
     CHECK: 2

--- a/test/unittests/codegen/system_4.mod
+++ b/test/unittests/codegen/system_4.mod
@@ -1,0 +1,33 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE System4;
+
+IMPORT SYSTEM, Out;
+
+TYPE
+  Date = RECORD day, month, year: INTEGER END;
+
+PROCEDURE Test;
+VAR 
+    xadr, yadr : LONGINT;
+    x, y : Date;
+BEGIN
+    x.day := 1 ; x.month := 2 ; x.year := 3;
+    y.day := -1 ; y.month := -2 ; y.year := -3;
+    xadr := SYSTEM.ADR(x);
+    yadr := SYSTEM.ADR(y);
+    SYSTEM.COPY(xadr, yadr, SYSTEM.SIZE(Date) DIV 4);
+    Out.Int(y.day, 0); Out.Ln;
+    Out.Int(y.month, 0); Out.Ln;
+    Out.Int(y.year, 0); Out.Ln
+END Test;
+
+BEGIN
+    Test
+END System4.
+(*
+    CHECK: 1
+    CHECK: 2
+    CHECK: 3
+*)


### PR DESCRIPTION
Add record and array support to SYSTEM.ADR.
COPY length argument is implemented as INTEGER size unit in Project Oberon. Changed accordingly.
Added some further unittests.