### PR TITLE
Disable stack protection for MSYS2

### DIFF
--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -21,7 +21,9 @@ LLVMIRBuilder::LLVMIRBuilder(CompilerConfig &config, LLVMContext &builder, Modul
         .addAttribute(Attribute::NoInline)
         .addAttribute(Attribute::NoUnwind)
         .addAttribute(Attribute::OptimizeNone)
+#ifndef __MINGW32__
         .addAttribute(Attribute::StackProtect)
+#endif
 #ifndef _LLVM_LEGACY
         .addAttribute(Attribute::getWithUWTableKind(builder, UWTableKind::Default))
 #endif


### PR DESCRIPTION
MSYS2 Clang does not seem to be compiled with stack protection.
Get unresolved symbol for '__stack_chk_guard'.