### PR TITLE
System add BIT and fix argument of COPY procedure

### DIFF
--- a/src/codegen/llvm/LLVMIRBuilder.h
+++ b/src/codegen/llvm/LLVMIRBuilder.h
@@ -98,6 +98,7 @@ private:
     Value *createSystemAdrCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemGetCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemPutCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
+    Value *createSystemBitCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemCopyCall(Value *, Value *, Value *);
     
     Value *createTrapCall(unsigned);

--- a/src/system/OberonSystem.cpp
+++ b/src/system/OberonSystem.cpp
@@ -148,7 +148,8 @@ void Oberon07::initSymbolTable(SymbolTable *symbols) {
     this->createProcedure(ProcKind::SYSTEM_ADR, "ADR", {{anyType, true}}, longType, false, true);
     this->createProcedure(ProcKind::SYSTEM_GET, "GET", {{longType, false}, {anyType, true}}, nullptr, false, true);
     this->createProcedure(ProcKind::SYSTEM_PUT, "PUT", {{longType, false}, {anyType, false}}, nullptr, false, true);
-    this->createProcedure(ProcKind::SYSTEM_COPY, "COPY", {{longType, false}, {longType, false}, {intType, false}}, nullptr, false, true);
+    this->createProcedure(ProcKind::SYSTEM_BIT, "BIT", {{longType, false}, {intType, false}}, boolType, false, true);
+    this->createProcedure(ProcKind::SYSTEM_COPY, "COPY", {{longType, false}, {longType, false}, {longType, false}}, nullptr, false, true);
     this->createProcedure(ProcKind::SYSTEM_SIZE, "SIZE", {{typeType, false}}, longType, false, true);
     leaveNamespace();
 }

--- a/test/unittests/codegen/system_5.mod
+++ b/test/unittests/codegen/system_5.mod
@@ -1,0 +1,29 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE System5;
+
+IMPORT SYSTEM, Out;
+
+PROCEDURE Test;
+VAR 
+    adr : LONGINT;
+    x : SET;
+BEGIN
+    x := {1, 31};
+    adr := SYSTEM.ADR(x);
+    Out.Int(ORD(SYSTEM.BIT(adr, 0)), 0); Out.Ln;
+    Out.Int(ORD(SYSTEM.BIT(adr, 1)), 0); Out.Ln;
+    Out.Int(ORD(SYSTEM.BIT(adr, 30)), 0); Out.Ln;
+    Out.Int(ORD(SYSTEM.BIT(adr, 31)), 0); Out.Ln
+END Test;
+
+BEGIN
+    Test
+END System5.
+(*
+    CHECK: 0
+    CHECK: 1
+    CHECK: 0
+    CHECK: 1
+*)


### PR DESCRIPTION
This add the SYSTEM.BIT procedure together with a unittest for this feature.
Also the size argument of SYSTEM.COPY changed to LONGINT and unittests should work again.

The SYSTEM module is now getting complete except for the VAL procedure which is currently
tricky as the return type depend on the TYPE argument. Same for the MIN & MAX procedures.

