### PR TITLE
Support casting predefined procedures (MIN, MAX, CAST, SYSTEM.VAL) [DRAFT]

### DIFF
--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -1309,21 +1309,21 @@ LLVMIRBuilder::createSizeCall(ExpressionNode *expr) {
 Value *
 LLVMIRBuilder::createMaxMinCall(ExpressionNode *actual, bool isMax) {
     auto decl = dynamic_cast<QualifiedExpression *>(actual)->dereference();
-    auto type = dynamic_cast<TypeDeclarationNode *>(decl);
-    if (type->getType()->isReal()) {
-        if (actual->getType()->getSize() == 4) {
+    auto type = dynamic_cast<TypeDeclarationNode *>(decl)->getType();
+    if (type->isReal()) {
+        if (type->getSize() == 4) {
             value_ = ConstantFP::getInfinity(builder_.getFloatTy(), isMax);
         } else {
             value_ = ConstantFP::getInfinity(builder_.getDoubleTy(), isMax);
         }
-    } else if (type->getType()->isInteger()) {
-        if (actual->getType()->getSize() == 8) {
+    } else if (type->isInteger()) {
+        if (type->getSize() == 8) {
             if (isMax) {
                 value_ = builder_.getInt64((uint64_t)(LLONG_MAX));
             } else {
                 value_ = builder_.getInt64((uint64_t)(LLONG_MIN));
             }
-        } else if (actual->getType()->getSize() == 4) {
+        } else if (type->getSize() == 4) {
             if (isMax) {
                 value_ = builder_.getInt32((uint32_t)(INT_MAX));
             } else {

--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -969,6 +969,8 @@ LLVMIRBuilder::createPredefinedCall(PredefinedProcedure *proc, QualIdent *ident,
             return createSystemBitCall(actuals, params);
         case ProcKind::SYSTEM_COPY:
             return createSystemCopyCall(params[0], params[1], params[2]);
+        case ProcKind::SYSTEM_VAL:
+            return createSystemValCall(actuals, params);
         default:
             logger_.error(ident->start(), "unsupported predefined procedure: " + to_string(*ident) + ".");
             // to generate correct LLVM IR, the current value is returned (no-op).
@@ -1450,6 +1452,41 @@ LLVMIRBuilder::createSystemCopyCall(llvm::Value *src, llvm::Value *dst, llvm::Va
     auto srcptr = builder_.CreateIntToPtr(src, ptrtype);
     auto dstptr = builder_.CreateIntToPtr(dst, ptrtype);
     return builder_.CreateMemCpy(dstptr, {}, srcptr, {}, builder_.CreateShl(n, 2), true);
+}
+
+Value *
+LLVMIRBuilder::createSystemValCall(vector<unique_ptr<ExpressionNode>> &actuals, std::vector<Value *> &params) {
+    // TODO : Support further types : RECORD etc
+    auto dst = actuals[0].get();
+    auto decl = dynamic_cast<QualifiedExpression *>(dst)->dereference();
+    auto dsttype = dynamic_cast<TypeDeclarationNode *>(decl)->getType();
+    auto src = actuals[1].get();
+    auto srctype = src->getType();
+    if (!srctype->isBasic() || !dsttype->isBasic()) {
+        logger_.error(dst->pos(), "expected basic type");
+        return value_;
+    }
+    Value *srcpar;
+    if (srctype->isReal()) {
+        if (srctype->getSize() == 4) {
+            srcpar = builder_.CreateBitCast(params[1], builder_.getInt32Ty());
+        } else {
+            srcpar = builder_.CreateBitCast(params[1], builder_.getInt64Ty());
+        }
+    } else {
+        srcpar = params[1];
+    }
+    if (dsttype->isReal()) {
+        if (dsttype->getSize() == 4) {
+            srcpar = builder_.CreateZExtOrTrunc(srcpar, builder_.getInt32Ty());
+            return builder_.CreateBitCast(srcpar, builder_.getFloatTy());
+        } else {
+            srcpar = builder_.CreateZExtOrTrunc(srcpar, builder_.getInt64Ty());
+            return builder_.CreateBitCast(srcpar, builder_.getDoubleTy());
+        }
+    } else {
+        return builder_.CreateZExtOrTrunc(srcpar, getLLVMType(dsttype));
+    }
 }
 
 Value *

--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -1476,17 +1476,19 @@ LLVMIRBuilder::createSystemValCall(vector<unique_ptr<ExpressionNode>> &actuals, 
     } else {
         srcpar = params[1];
     }
+    if (srctype->getSize() <= dsttype->getSize()) {
+        srcpar = builder_.CreateZExt(srcpar, getLLVMType(dsttype));
+    } else {
+        srcpar = builder_.CreateTrunc(srcpar, getLLVMType(dsttype));
+    }
     if (dsttype->isReal()) {
         if (dsttype->getSize() == 4) {
-            srcpar = builder_.CreateZExtOrTrunc(srcpar, builder_.getInt32Ty());
             return builder_.CreateBitCast(srcpar, builder_.getFloatTy());
         } else {
-            srcpar = builder_.CreateZExtOrTrunc(srcpar, builder_.getInt64Ty());
             return builder_.CreateBitCast(srcpar, builder_.getDoubleTy());
         }
-    } else {
-        return builder_.CreateZExtOrTrunc(srcpar, getLLVMType(dsttype));
     }
+    return srcpar;
 }
 
 Value *

--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -1319,21 +1319,21 @@ LLVMIRBuilder::createMaxMinCall(ExpressionNode *actual, bool isMax) {
     } else if (type->isInteger()) {
         if (type->getSize() == 8) {
             if (isMax) {
-                value_ = builder_.getInt64((uint64_t)(LLONG_MAX));
+                value_ = builder_.getInt64((uint64_t)std::numeric_limits<int64_t>::max());
             } else {
-                value_ = builder_.getInt64((uint64_t)(LLONG_MIN));
+                value_ = builder_.getInt64((uint64_t)std::numeric_limits<int64_t>::min());
             }
         } else if (type->getSize() == 4) {
             if (isMax) {
-                value_ = builder_.getInt32((uint32_t)(INT_MAX));
+                value_ = builder_.getInt32((uint32_t)std::numeric_limits<int32_t>::max());
             } else {
-                value_ = builder_.getInt32((uint32_t)(INT_MIN));
+                value_ = builder_.getInt32((uint32_t)std::numeric_limits<int32_t>::min());
             }
         } else {
             if (isMax) {
-                value_ = builder_.getInt64((uint16_t)(SHRT_MAX));
+                value_ = builder_.getInt64((uint16_t)std::numeric_limits<int16_t>::max());
             } else {
-                value_ = builder_.getInt64((uint16_t)(SHRT_MIN));
+                value_ = builder_.getInt64((uint16_t)std::numeric_limits<int16_t>::min());
             }
         }
     } else {

--- a/src/codegen/llvm/LLVMIRBuilder.h
+++ b/src/codegen/llvm/LLVMIRBuilder.h
@@ -98,7 +98,8 @@ private:
     Value *createRorCall(Value *, Value *);
     Value *createShortCall(ExpressionNode *, Value *);
     Value *createSizeCall(ExpressionNode *);
-    
+    Value *createMaxMinCall(ExpressionNode *, bool);
+
     Value *createSystemAdrCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemGetCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemPutCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);

--- a/src/codegen/llvm/LLVMIRBuilder.h
+++ b/src/codegen/llvm/LLVMIRBuilder.h
@@ -99,12 +99,13 @@ private:
     Value *createShortCall(ExpressionNode *, Value *);
     Value *createSizeCall(ExpressionNode *);
     Value *createMaxMinCall(ExpressionNode *, bool);
-
+    
     Value *createSystemAdrCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemGetCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemPutCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemBitCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createSystemCopyCall(Value *, Value *, Value *);
+    Value *createSystemValCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     
     Value *createTrapCall(unsigned);
     Value *createInBoundsCheck(Value *, Value *, Value *);

--- a/src/data/ast/ProcedureTypeNode.cpp
+++ b/src/data/ast/ProcedureTypeNode.cpp
@@ -14,6 +14,10 @@ bool ProcedureTypeNode::hasVarArgs() const {
     return varargs_;
 }
 
+void ProcedureTypeNode::setReturnType(TypeNode *type) {
+    type_ = type;
+}
+
 TypeNode *ProcedureTypeNode::getReturnType() const {
     return type_;
 }

--- a/src/data/ast/ProcedureTypeNode.h
+++ b/src/data/ast/ProcedureTypeNode.h
@@ -34,6 +34,7 @@ public:
 
     [[nodiscard]] bool hasVarArgs() const;
 
+    void setReturnType(TypeNode *);
     [[nodiscard]] TypeNode *getReturnType() const;
 
     void accept(NodeVisitor &visitor) final;

--- a/src/system/OberonSystem.cpp
+++ b/src/system/OberonSystem.cpp
@@ -192,5 +192,6 @@ void Oberon07::initSymbolTable(SymbolTable *symbols) {
     this->createProcedure(ProcKind::SYSTEM_BIT, "BIT", {{longIntType, false}, {intType, false}}, boolType, false, true);
     this->createProcedure(ProcKind::SYSTEM_COPY, "COPY", {{longIntType, false}, {longIntType, false}, {longIntType, false}}, nullptr, false, true);
     this->createProcedure(ProcKind::SYSTEM_SIZE, "SIZE", {{typeType, false}}, longIntType, false, true);
+    this->createProcedure(ProcKind::SYSTEM_VAL, "VAL", {{typeType, false},{anyType, false}}, typeType, false, true);
     leaveNamespace();
 }

--- a/src/system/OberonSystem.cpp
+++ b/src/system/OberonSystem.cpp
@@ -182,6 +182,8 @@ void Oberon07::initSymbolTable(SymbolTable *symbols) {
     proc->overload({{longIntType, false}}, false, longIntType);
     proc->overload({{realType, false}}, false, realType);
     proc->overload({{longRealType, false}}, false, longRealType);
+    this->createProcedure(ProcKind::MAX, "MAX", {{typeType, false}}, typeType, false, true);
+    this->createProcedure(ProcKind::MIN, "MIN", {{typeType, false}}, typeType, false, true);
 
     createNamespace("SYSTEM");
     this->createProcedure(ProcKind::SYSTEM_ADR, "ADR", {{anyType, true}}, longIntType, false, true);

--- a/src/system/PredefinedProcedure.cpp
+++ b/src/system/PredefinedProcedure.cpp
@@ -16,7 +16,7 @@ using std::vector;
 
 PredefinedProcedure::PredefinedProcedure(ProcKind kind, const string &name,
                                          const vector<pair<TypeNode *, bool>> &pairs, bool varargs, TypeNode *ret) :
-        ProcedureNode(make_unique<IdentDef>(name), nullptr), types_(), isCast_(), castSignature_(), kind_(kind) {
+        ProcedureNode(make_unique<IdentDef>(name), nullptr), types_(), isCast_(), kind_(kind) {
     auto type = overload(pairs, varargs, ret);
     this->setType(type);
     isCast_ = false;
@@ -48,9 +48,9 @@ PredefinedProcedure::overload(const vector<pair<TypeNode *, bool>> &pairs, bool 
 
 ProcedureTypeNode *PredefinedProcedure::dispatch(vector<TypeNode *> actuals, TypeNode *typeType) {
     if (isCast_ && typeType) {
-        if (castSignature_) delete castSignature_;
-        castSignature_ = new ProcedureTypeNode(EMPTY_POS, this->getIdentifier(), std::move(types_[0]->parameters()), types_[0]->hasVarArgs(), std::move(typeType));
-        return castSignature_;
+        auto signature = types_[0].get();
+        signature->setReturnType(typeType); // TODO : mutate not ideal
+        return signature;
     }
     for (const auto& type : types_) {
         auto signature = type.get();

--- a/src/system/PredefinedProcedure.cpp
+++ b/src/system/PredefinedProcedure.cpp
@@ -58,7 +58,7 @@ ProcedureTypeNode *PredefinedProcedure::dispatch(vector<TypeNode *> actuals, Typ
         return nullptr;
     }
     if ((castIdx_ > 0) && typeType) {
-        auto signature = make_unique<ProcedureTypeNode>(EMPTY_POS, this->getIdentifier(), std::move(types_[0]->parameters()), types_[0]->hasVarArgs(), typeType);
+        auto signature = make_unique<ProcedureTypeNode>(EMPTY_POS, this->getIdentifier(), std::move(types_[0]->parameters()), types_[0]->hasVarArgs(), std::move(typeType));
         return std::move(signature.get());
     }
     for (const auto& type : types_) {

--- a/src/system/PredefinedProcedure.h
+++ b/src/system/PredefinedProcedure.h
@@ -30,7 +30,6 @@ class PredefinedProcedure : public ProcedureNode {
 private:
     vector<unique_ptr<ProcedureTypeNode>> types_;
     bool isCast_;
-    ProcedureTypeNode *castSignature_;
     ProcKind kind_;
 
 public:

--- a/src/system/PredefinedProcedure.h
+++ b/src/system/PredefinedProcedure.h
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include "data/ast/ProcedureNode.h"
+#include "data/ast/ASTContext.h"
+#include "data/ast/NodeVisitor.h"
 
 using std::make_unique;
 using std::pair;
@@ -25,10 +27,11 @@ enum class ProcKind {
     SYSTEM_ADR, SYSTEM_GET, SYSTEM_PUT, SYSTEM_SIZE, SYSTEM_BIT, SYSTEM_COPY, SYSTEM_VAL
 };
 
-class PredefinedProcedure final : public ProcedureNode {
+class PredefinedProcedure : public ProcedureNode {
 
 private:
     vector<unique_ptr<ProcedureTypeNode>> types_;
+    int castIdx_;
     ProcKind kind_;
 
 public:
@@ -36,7 +39,7 @@ public:
     ~PredefinedProcedure() override;
 
     ProcedureTypeNode* overload(const vector<pair<TypeNode*, bool>> &, bool, TypeNode *);
-    ProcedureTypeNode* dispatch(vector<TypeNode*>) const;
+    ProcedureTypeNode* dispatch(vector<TypeNode*>, TypeNode *) const;
     [[nodiscard]] bool isOverloaded() const;
 
     [[nodiscard]] ProcKind getKind() const;

--- a/src/system/PredefinedProcedure.h
+++ b/src/system/PredefinedProcedure.h
@@ -12,8 +12,6 @@
 #include <vector>
 
 #include "data/ast/ProcedureNode.h"
-#include "data/ast/ASTContext.h"
-#include "data/ast/NodeVisitor.h"
 
 using std::make_unique;
 using std::pair;
@@ -31,7 +29,8 @@ class PredefinedProcedure : public ProcedureNode {
 
 private:
     vector<unique_ptr<ProcedureTypeNode>> types_;
-    int castIdx_;
+    bool isCast_;
+    ProcedureTypeNode *castSignature_;
     ProcKind kind_;
 
 public:
@@ -39,7 +38,7 @@ public:
     ~PredefinedProcedure() override;
 
     ProcedureTypeNode* overload(const vector<pair<TypeNode*, bool>> &, bool, TypeNode *);
-    ProcedureTypeNode* dispatch(vector<TypeNode*>, TypeNode *) const;
+    ProcedureTypeNode* dispatch(vector<TypeNode*>, TypeNode *);
     [[nodiscard]] bool isOverloaded() const;
 
     [[nodiscard]] ProcKind getKind() const;

--- a/test/unittests/codegen/system_6.mod
+++ b/test/unittests/codegen/system_6.mod
@@ -1,0 +1,52 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE System6;
+
+IMPORT SYSTEM, Out;
+
+PROCEDURE Test;
+VAR 
+    x : LONGREAL;
+    y : REAL;
+    a : LONGINT;
+    b : INTEGER;
+    c : SHORTINT;
+BEGIN
+    x := MAX(LONGREAL);
+    Out.LongReal(x); Out.Ln;
+    x := MIN(LONGREAL);
+    Out.LongReal(x); Out.Ln;
+    y := MAX(REAL);
+    Out.Real(y, 7); Out.Ln;
+    y := MIN(REAL);
+    Out.Real(y, 7); Out.Ln;
+    a := MAX(LONGINT);
+    Out.Long(a, 0); Out.Ln;
+    a := MIN(LONGINT);
+    Out.Long(a, 0); Out.Ln;
+    b := MAX(INTEGER);
+    Out.Int(b, 0); Out.Ln;
+    b := MIN(INTEGER);
+    Out.Int(b, 0); Out.Ln;
+    c := MAX(SHORTINT);
+    Out.Int(c, 0); Out.Ln;
+    c := MIN(SHORTINT);
+    Out.Int(c, 0); Out.Ln
+END Test;
+
+BEGIN
+    Test
+END System6.
+(*
+    CHECK: INF
+    CHECK: -INF
+    CHECK: INF
+    CHECK: -INF
+    CHECK: 9223372036854775807
+    CHECK: -9223372036854775808
+    CHECK: 2147483647
+    CHECK: -2147483648
+    CHECK: 32767
+    CHECK: -32768
+*)

--- a/test/unittests/codegen/system_7.mod
+++ b/test/unittests/codegen/system_7.mod
@@ -1,0 +1,36 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE System7;
+
+IMPORT SYSTEM, Out;
+
+PROCEDURE Test;
+VAR 
+    a : LONGINT;
+    b : INTEGER;
+    c : SHORTINT;
+BEGIN
+    a := 0DEADBEEFH;
+    Out.LongHex(a); Out.Ln;
+    b := SYSTEM.VAL(INTEGER, a);
+    Out.Hex(b); Out.Ln;
+    c := SYSTEM.VAL(SHORTINT, a);
+    Out.Hex(c); Out.Ln;
+    c := 0BEEFH;
+    b := SYSTEM.VAL(INTEGER, c);
+    Out.Hex(b); Out.Ln;
+    a := SYSTEM.VAL(LONGINT, c);
+    Out.LongHex(a); Out.Ln
+END Test;
+
+BEGIN
+    Test
+END System7.
+(*
+    CHECK: 00000000DEADBEEF
+    CHECK: DEADBEEF
+    CHECK: 0000BEEF
+    CHECK: 0000BEEF
+    CHECK: 000000000000BEEF
+*)


### PR DESCRIPTION
This implements casting predefined procedures.
When return type is set to `typeType `it expects one of the arguments to be of type `typeType`.
This arguments type is used to infer the return type of the procedure.

The procedures `MIN `and `MAX `is implemented.
There seems to be a problem with mutating arguments:

> PROCEDURE Test;
> VAR 
>     a : LONGINT;
>     b : INTEGER;
> BEGIN
>     a := MAX(LONGINT);
>     a := MIN(LONGINT);
>     b := MAX(INTEGER);
>     b := MIN(INTEGER)
> END Test;

This fails with:

> error: more actual than formal parameters.

on the expression `b := MAX(INTEGER)`

Otherwise this works as expected.
