### PR TITLE
Fix SYSTEM.VAL and update unittest

### DIFF
--- a/src/codegen/llvm/LLVMIRBuilder.cpp
+++ b/src/codegen/llvm/LLVMIRBuilder.cpp
@@ -1478,19 +1478,20 @@ LLVMIRBuilder::createSystemValCall(vector<unique_ptr<ExpressionNode>> &actuals, 
     } else {
         srcpar = params[1];
     }
-    if (srctype->getSize() <= dsttype->getSize()) {
-        srcpar = builder_.CreateZExt(srcpar, getLLVMType(dsttype));
-    } else {
-        srcpar = builder_.CreateTrunc(srcpar, getLLVMType(dsttype));
-    }
     if (dsttype->isReal()) {
-        if (dsttype->getSize() == 4) {
-            return builder_.CreateBitCast(srcpar, builder_.getFloatTy());
+        auto rcast = dsttype->getSize() == 4 ? builder_.getInt32Ty() : builder_.getInt64Ty();
+        if (srctype->getSize() <= dsttype->getSize()) {
+            srcpar = builder_.CreateZExt(srcpar, rcast);
         } else {
-            return builder_.CreateBitCast(srcpar, builder_.getDoubleTy());
+            srcpar = builder_.CreateTrunc(srcpar, rcast);
         }
+        return builder_.CreateBitCast(srcpar, getLLVMType(dsttype));
     }
-    return srcpar;
+    if (srctype->getSize() <= dsttype->getSize()) {
+        return builder_.CreateZExt(srcpar, getLLVMType(dsttype));
+    } else {
+        return builder_.CreateTrunc(srcpar, getLLVMType(dsttype));
+    }
 }
 
 Value *

--- a/test/unittests/codegen/system_7.mod
+++ b/test/unittests/codegen/system_7.mod
@@ -7,30 +7,40 @@ IMPORT SYSTEM, Out;
 
 PROCEDURE Test;
 VAR 
+    x : LONGREAL;
+    y : REAL;
     a : LONGINT;
     b : INTEGER;
     c : SHORTINT;
+    d : SET;
 BEGIN
-    a := 0DEADBEEFH;
-    Out.LongHex(a); Out.Ln;
-    b := SYSTEM.VAL(INTEGER, a);
-    Out.Hex(b); Out.Ln;
-    c := SYSTEM.VAL(SHORTINT, a);
-    Out.Hex(c); Out.Ln;
-    c := 0BEEFH;
-    b := SYSTEM.VAL(INTEGER, c);
-    Out.Hex(b); Out.Ln;
-    a := SYSTEM.VAL(LONGINT, c);
-    Out.LongHex(a); Out.Ln
+    a := 1234567890;
+    Out.Long(a, 0); Out.Ln;
+    b := SYSTEM.VAL(INTEGER, a DIV 10);
+    Out.Int(b, 0); Out.Ln;
+    c := SYSTEM.VAL(SHORTINT, b DIV 10000);
+    Out.Int(c, 0); Out.Ln;
+    b := 0DEADBEEFH;
+    d := SYSTEM.VAL(SET, b);
+    Out.Hex(SYSTEM.VAL(INTEGER, d)); Out.Ln;
+    x := -1.0;
+    Out.LongHex(SYSTEM.VAL(LONGINT, x)); Out.Ln;
+    y := -1.0;
+    Out.Hex(SYSTEM.VAL(INTEGER, y)); Out.Ln;
+    b := 0BF800000H;
+    y := SYSTEM.VAL(REAL, b);
+    Out.Real(y,0); Out.Ln
 END Test;
 
 BEGIN
     Test
 END System7.
 (*
-    CHECK: 00000000DEADBEEF
+    CHECK: 1234567890
+    CHECK: 123456789
+    CHECK: 12345
     CHECK: DEADBEEF
-    CHECK: 0000BEEF
-    CHECK: 0000BEEF
-    CHECK: 000000000000BEEF
+    CHECK: BFF0000000000000
+    CHECK: BF800000
+    CHECK:  -1.0E+00
 *)


### PR DESCRIPTION
SYSTEM.VAL should be fixed now.
system_6.mod still fails. Probably some issue in the Out module:

-INF
INF
NaN
NaN
-1
0
2147483647
-2147483648
32767
-32768

I see that `long` is used in `rt_out_int` which is 32bit on my platform (Windows) and will overflow with `LONGINT`.