### PR TITLE
Add basic automatic API documetation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,6 +34,13 @@ jobs:
         sudo pip3 install sphinx
         sudo pip3 install sphinx_rtd_theme
 
+    - name: API build
+      run: |
+        python ${{ github.workspace }}/tools/docgen.py ${{ github.workspace }}/liboberon/Math.Mod >${{ github.workspace }}/docs/src/API_Math.rst
+        python ${{ github.workspace }}/tools/docgen.py ${{ github.workspace }}/liboberon/Oberon.Mod >${{ github.workspace }}/docs/src/API_Oberon.rst
+        python ${{ github.workspace }}/tools/docgen.py ${{ github.workspace }}/liboberon/Out.Mod >${{ github.workspace }}/docs/src/API_Out.rst
+        python ${{ github.workspace }}/tools/docgen.py ${{ github.workspace }}/liboberon/Random.Mod >${{ github.workspace }}/docs/src/API_Random.rst
+
     - name: Sphinx build
       run: sphinx-build ${{ github.workspace }}/docs ${{ github.workspace }}/build/
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -5,6 +5,21 @@ if(Sphinx-NOTFOUND)
 else()
         set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
         set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/sphinx/)
+        
+        function(add_oberon_module source dest)
+        add_custom_command(
+        OUTPUT ${dest}
+        COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../tools/docgen.py
+                ${source}
+                > ${dest}
+        DEPENDS ${source}
+        )
+        endfunction()
+        
+        add_oberon_module("${CMAKE_CURRENT_SOURCE_DIR}/../liboberon/Math.Mod" "${SPHINX_SOURCE}/src/API_Math.rst")
+        add_oberon_module("${CMAKE_CURRENT_SOURCE_DIR}/../liboberon/Oberon.Mod" "${SPHINX_SOURCE}/src/API_Oberon.rst")
+        add_oberon_module("${CMAKE_CURRENT_SOURCE_DIR}/../liboberon/Out.Mod" "${SPHINX_SOURCE}/src/API_Out.rst")
+        add_oberon_module("${CMAKE_CURRENT_SOURCE_DIR}/../liboberon/Random.Mod" "${SPHINX_SOURCE}/src/API_Random.rst")
 
         add_custom_target(docs
                 COMMAND ${SPHINX_EXECUTABLE} -b html
@@ -16,6 +31,10 @@ else()
                         ${SPHINX_SOURCE}/src/FAQ.rst
                         ${SPHINX_SOURCE}/src/GettingStarted.rst
                         ${SPHINX_SOURCE}/src/Installation.rst
+                        ${SPHINX_SOURCE}/src/API_Math.rst
+                        ${SPHINX_SOURCE}/src/API_Oberon.rst
+                        ${SPHINX_SOURCE}/src/API_Out.rst
+                        ${SPHINX_SOURCE}/src/API_Random.rst
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 COMMENT "Generating documentation with Sphinx")
         

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,10 @@ for basic usage specific features.
    src/Installation
    src/GettingStarted
    src/CommandLineInterface
+   src/API_Math.rst
+   src/API_Oberon.rst
+   src/API_Out.rst
+   src/API_Random.rst
    src/FAQ
 
 ##################

--- a/docs/src/CommandLineInterface.rst
+++ b/docs/src/CommandLineInterface.rst
@@ -7,8 +7,7 @@
 Command Line Interface
 **********************
 
-SYNOPSIS
-========
+.. rubric:: SYNOPSIS
 
 .. code-block:: shell
 
@@ -16,8 +15,7 @@ SYNOPSIS
     oberon-lang --version
     oberon-lang [-v|--verbose] [-q|--quiet] [-I path] [-L path] [-l library,...] [-f flag,...] [-O level] [-o name] [-r|--run] module ...
 
-DESCRIPTION
-===========
+.. rubric:: DESCRIPTION
 
 *oberon-lang* is a compiler for the *Oberon* language family utilizing the *LLVM* compiler
 infrastructure to target at wide variety of platforms. By default it built one or several
@@ -25,8 +23,7 @@ supplied modules to object files. With the "[-r|--run]" flag set it executes dir
 single module. In order to create and executable a single module must be marked as the
 main module with the "[-f enable-main]" flag.
 
-OPTIONS
-=======
+.. rubric:: OPTIONS
 
 -h, --help          Show help message and exit.
 --version           Show version information and exit.
@@ -46,13 +43,11 @@ OPTIONS
 -o name             Name of the output file.
 -r, --run           Run with LLVM JIT.
 
-AUTHOR
-======
+.. rubric:: AUTHOR
 
 Michael Grossniklaus
 
-COPYRIGHT
-=========
+.. rubric:: COPYRIGHT
 
 MIT License
 

--- a/liboberon/Math.Mod
+++ b/liboberon/Math.Mod
@@ -1,3 +1,4 @@
+(** Module with math function operation on `REAL` type. *)
 MODULE Math;
 
 CONST e* = 2.7182818284;
@@ -12,45 +13,52 @@ PROCEDURE atanf(x: REAL): REAL; EXTERN;
 PROCEDURE rt_realf(x: INTEGER): REAL; EXTERN;
 PROCEDURE rt_entierf(x: REAL): INTEGER; EXTERN;
 
+(** Computes the square root of the `REAL` x *)
 PROCEDURE sqrt*(x: REAL): REAL;
 BEGIN
     RETURN sqrtf(x)
 END sqrt;
 
+(** Computes e raised to the power of x *)
 PROCEDURE exp*(x: REAL): REAL;
 BEGIN
     RETURN expf(x)
 END exp;
 
+(** Computes natural (e) logarithm of x *)
 PROCEDURE ln*(x: REAL): REAL;
 BEGIN
     RETURN logf(x)
 END ln;
 
+(** Computes the sine of the angle `REAL` x in radians *)
 PROCEDURE sin*(x: REAL): REAL;
 BEGIN
     RETURN sinf(x)
 END sin;
 
+(** Computes the cosine of the angle `REAL` x in radians *)
 PROCEDURE cos*(x: REAL): REAL;
 BEGIN
     RETURN cosf(x)
 END cos;
 
+(** Computes the arc tangent of the value `REAL` x *)
 PROCEDURE arctan*(x: REAL): REAL;
 BEGIN
     RETURN atanf(x)
 END arctan;
 
+(** Return the `INTEGER` x converted to `REAL` *)
 PROCEDURE real*(x: INTEGER): REAL;
 BEGIN
     RETURN rt_realf(x)
 END real;
 
+(** Computes the largest integer value not greater than x *)
 PROCEDURE entier*(x: REAL): INTEGER;
 BEGIN
     RETURN rt_entierf(x)
 END entier;
 
 END Math.
-

--- a/liboberon/Oberon.Mod
+++ b/liboberon/Oberon.Mod
@@ -1,3 +1,4 @@
+(** Module with various system functions *)
 MODULE Oberon;
 
 CONST TIMEUTC* = 1;
@@ -16,12 +17,14 @@ PROCEDURE time(t: LONGINT): LONGINT; EXTERN;
 (* Import `timespec_get` function from C <time.h> library. *)
 PROCEDURE rt_timespec_get(VAR ts: TimeSpec; base: INTEGER); EXTERN;
 
+(** Return elapsed clock ticks since program start *)
 PROCEDURE Time*(): LONGINT;
 VAR t: LONGINT;
 BEGIN
     RETURN time(0)
 END Time;
 
+(** Return elapsed milliseconds since program start *)
 PROCEDURE TimeMillis*(): LONGINT;
 VAR ts: TimeSpec;
 BEGIN
@@ -29,6 +32,7 @@ BEGIN
     RETURN ts.secs * 1000 + ts.nsecs DIV 1000000
 END TimeMillis;
 
+(** Return elapsed microseconds since program start *)
 PROCEDURE TimeMicros*(): LONGINT;
 VAR ts: TimeSpec;
 BEGIN
@@ -36,6 +40,7 @@ BEGIN
     RETURN ts.secs * 1000000 + ts.nsecs DIV 1000
 END TimeMicros;
 
+(** Return elapsed nanoseconds since program start *)
 PROCEDURE TimeNanos*(): LONGINT;
 VAR ts: TimeSpec;
 BEGIN

--- a/liboberon/Out.Mod
+++ b/liboberon/Out.Mod
@@ -1,3 +1,4 @@
+(**  Module with a set of basic routines for formatted output of characters, numbers and strings. *)
 MODULE Out;
 
   IMPORT Texts;
@@ -5,61 +6,61 @@ MODULE Out;
   VAR
     W: Texts.Writer;
 
-  (* Writes the character `ch` to the output. *)
+  (** Writes the character `ch` to the output. *)
   PROCEDURE Char* (ch: CHAR);
   BEGIN
     Texts.Write(W, ch)
   END Char;
 
-  (* Writes the string `s` to the output. *)
+  (** Writes the string `s` to the output. *)
   PROCEDURE String* (s: ARRAY OF CHAR);
   BEGIN
     Texts.WriteString(W, s)
   END String;
 
-  (* Outputs a newline. *)
+  (** Outputs a newline. *)
   PROCEDURE Ln*;
   BEGIN
     Texts.WriteLn(W)
   END Ln;
 
-  (* Writes the integer `x` in `n` field positions. *)
+  (** Writes the integer `x` in `n` field positions. *)
   PROCEDURE Int* (x: INTEGER; n: INTEGER);
   BEGIN
     Texts.WriteInt(W, x, n)
   END Int;
 
-  (* Writes the long integer `x` in `n` field positions. *)
+  (** Writes the long integer `x` in `n` field positions. *)
   PROCEDURE Long* (x: LONGINT; n: INTEGER);
   BEGIN
     Texts.WriteInt(W, x, n)
   END Long;
 
-  (* Writes the integer `x` in hexadecimal notation. *)
+  (** Writes the integer `x` in hexadecimal notation. *)
   PROCEDURE Hex* (x: INTEGER);
   BEGIN
     Texts.WriteHex(W, x)
   END Hex;
 
-  (* Writes the long integer `x` in hexadecimal notation. *)
+  (** Writes the long integer `x` in hexadecimal notation. *)
   PROCEDURE LongHex* (x: LONGINT);
   BEGIN
     Texts.WriteLongHex(W, x)
   END LongHex;
 
-  (* Writes the real `x` in `n` field positions. *)
+  (** Writes the real `x` in `n` field positions. *)
   PROCEDURE Real* (x: REAL; n: INTEGER);
   BEGIN
     Texts.WriteReal(W, x, n)
   END Real;
 
-  (* Writes the long real `x` in `n` field positions. *)
+  (** Writes the long real `x` in `n` field positions. *)
   PROCEDURE LongReal* (x: LONGREAL; n: INTEGER);
   BEGIN
     Texts.WriteLongReal(W, x, n)
   END LongReal;
 
-  (* Writes the set `set` to the output. *)
+  (** Writes the set `set` to the output. *)
   PROCEDURE Set* (set: SET);
   VAR i: INTEGER;
   BEGIN

--- a/liboberon/Random.Mod
+++ b/liboberon/Random.Mod
@@ -1,3 +1,4 @@
+(** Module with apseudo-random number generator *)
 MODULE Random;
 IMPORT Oberon;
 
@@ -7,11 +8,13 @@ PROCEDURE rand(): INTEGER; EXTERN;
 (* Import `srand` function from C <stdlib.h> library. *)
 PROCEDURE srand(seed: LONGINT); EXTERN;
 
+(** Returns next random integer number from 0 to max *)
 PROCEDURE Int*(max: INTEGER): INTEGER;
 BEGIN
     RETURN rand() MOD max
 END Int;
 
+(** Reset the random process with the current time *)
 PROCEDURE Randomize*();
 VAR time: LONGINT;
 BEGIN

--- a/tools/docgen.py
+++ b/tools/docgen.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env -S python
+# Simple parser to output Sphinx documentation
+# Author : Runar Tenfjord
+# TODO : replace by real C++ parser when this is stable
+import sys
+import argparse
+from collections import namedtuple
+from enum import Enum
+import re
+
+Module = namedtuple('Module', ['name', 'entries', 'doc'])
+
+Span = namedtuple('Span', ['start', 'end'])
+
+Token = namedtuple('Token', ['type', 'value', 'span'])
+
+Type = Enum('Type',[
+    'KEYWORD', 'TYPE', 'BUILTIN','IDENTIFIER', 'CLINE', 'CSTART', 'CEND', 'DSTART', 'DEND',
+    'OPERATOR', 'STRING', 'CCHAR', 'NUMBER', 'LPAR', 'RPAR', 'LBRA', 'RBRA', 'COLON',
+    'COM', 'SEMI', 'WHITESPACE', 'NEWLINE', 'MISMATCH'
+])
+
+EntryType = Enum('EntryType',['PROCEDURE', 'VAR', 'CONST', 'TYPE', 'IMPORT', 'COMMENT'])
+Entry = namedtuple('Entry', ['type', 'name',  'span', 'doc', 'ref'])
+
+keywords = {
+    'AND','ARRAY','BEGIN','CASE','CONST','DEFINITION','DIV','ELSE','ELSIF','END','EXPORT','FROM','IF','IMPLEMENTATION',
+    'IMPORT','MODULE','MOD','NOT','OF','OR','POINTER','PROCEDURE','RECORD','QUALIFIED','RETURN','SET','THEN','TYPE','VAR',
+    'WITH','EXIT','FOR','LOOP','REPEAT','UNTIL','WHILE','TRUE','FALSE','NIL'
+}
+
+types = {
+    'INTEGER','LONGINT','SHORTINT','BOOLEAN','REAL','LONGREAL','CHAR','SET'
+}
+
+builtins = {
+    'NEW','DISPOSE','INC','DEC','INCL','EXCL','HALT','ABS','CAP','CHR','FLOAT','HIGH','LFLOAT','LTRUNC','MIN','MAX','ODD','SFLOAT',
+    'STRUNC','TRUNC','VAL','IM','INT','LENGTH','ODD','RE'
+}
+
+operators = {
+    'IN', 'IS', 'DIV', 'MOD', 'AND','OR', 'XOR'
+}
+
+patterns = [
+    (Type.IDENTIFIER,   r'[_a-zA-Z][_a-zA-Z0-9]*'),
+    (Type.CLINE,       r'\-\-'),
+    (Type.CSTART,       r'(\(\*)'),
+    (Type.CEND,         r'\*\)'),
+    (Type.DSTART,       r'<\*'),
+    (Type.DEND,         r'\*>'),
+    (Type.OPERATOR,     r'(:=|:|\.|\+|\-|\*|/|\^|~|#|&|(<=)|<|(>=)|>|=)'),
+    (Type.STRING,       r"""".*?"|'.*?'"""),
+    (Type.CCHAR,        r"([0-7]+C)|(0[A-F0-9]*X)"),
+    (Type.NUMBER,       r"(0[A-F0-9]*H)|(\d*(\.)?\d+((E|D([-+])?)?\d+)?)|(\d+)"),
+    (Type.LPAR,         r'\('),
+    (Type.RPAR,         r'\)'),
+    (Type.LBRA,         r'\['),
+    (Type.RBRA,         r'\]'),
+    (Type.COLON,        r':'),
+    (Type.COM,          r','),
+    (Type.SEMI,         r';'),
+    (Type.WHITESPACE,   r'[ \t]+'),
+    (Type.NEWLINE,      r'\n'),
+    (Type.MISMATCH,     r'.' )        
+]
+regex = re.compile('|'.join('(?P<%s>%s)' % (type.name, pattern) for type, pattern in patterns))
+
+def parse(st):
+    def tokens(text):
+        for match in re.finditer(regex, text):
+            if match.lastgroup:
+                type = Type[match.lastgroup]
+                if type == Type.WHITESPACE:
+                    continue
+                elif type == Type.IDENTIFIER:
+                    if match[0] in keywords:
+                        type = Type.KEYWORD
+                    elif match[0] in types:
+                        type = Type.TYPE
+                    elif match[0] in builtins:
+                        type = Type.BUILTIN
+                    elif match[0] in operators:
+                        type = Type.OPERATOR
+                yield Token(type, match[0], Span(*match.span(0)))
+    
+    iter = tokens(st)
+    start = None
+    module = None
+    name = None
+    mtype = None
+    comment = None
+
+    def skip(current):
+        comment = None
+        clevel = 0
+        while True:
+            if current.type == Type.NEWLINE:
+                current = next(iter)
+                continue
+            elif current.type == Type.CLINE:
+                comment = None
+                start = current.span.start
+                while current.type != Type.NEWLINE:
+                    current = next(iter)
+                comment = Entry(EntryType.COMMENT, '', Span(start, current.span.end), None, None)
+                current = next(iter)
+                continue
+            elif current.type == Type.CSTART:
+                comment = None
+                clevel = 1
+                start = current.span.start
+                current = next(iter)
+                while clevel > 0:
+                    if current.type == Type.CSTART:
+                        clevel += 1
+                    elif current.type == Type.CEND:
+                        clevel -= 1
+                    else:
+                        pass
+                    current = next(iter)
+                comment = Entry(EntryType.COMMENT, '', Span(start, current.span.end), None, None)
+                current = next(iter)
+                continue
+            elif current.type == Type.DSTART:
+                while current.type != Type.DEND:
+                    current = next(iter)
+                current = next(iter)
+                continue
+            break
+        return current, comment
+    
+    try:
+        current = next(iter)
+        while True:
+            current, comment = skip(current)
+            if current.type == Type.KEYWORD:
+                if module is None:
+                    if current.value == 'MODULE':
+                        current = next(iter)
+                        if current.type == Type.IDENTIFIER:
+                            module = Module(current.value, [], comment)
+                            comment = None
+                            current = next(iter)
+                        continue
+                else:
+                    if current.value == "END":
+                        current = next(iter)
+                        if current.type == Type.IDENTIFIER and current.value == module.name:
+                            current = next(iter)
+                            if current.type == Type.OPERATOR and current.value == '.':
+                                current = next(iter)
+                            break
+
+                    elif current.value == 'IMPORT':
+                        while True:
+                            if current.type != Type.IDENTIFIER:
+                                break
+                            module.entries.append(Entry(EntryType.IMPORT, current.value, current.span, name, None))
+                            current = next(iter)
+                            if current.type == Type.COM:
+                                current = next(iter)
+                        comment = None
+
+                    elif current.value == 'CONST':
+                        current = next(iter)
+                        while True:
+                            current, comment = skip(current)
+                            if current.type != Type.IDENTIFIER:
+                                break
+                            start = current.span.start
+                            name = current.value
+                            current = next(iter)
+
+                            export = False
+                            if current.value == '*':
+                                export = True
+                                current = next(iter)
+
+                            if current.type != Type.OPERATOR or current.value != '=':
+                                break
+                            current = next(iter)
+                            while True:
+                                if current.type == Type.SEMI:
+                                    break
+                                current = next(iter)
+                            
+                            if export:
+                                module.entries.append(Entry(EntryType.CONST, name, Span(start, current.span.end), None, None))
+                            current = next(iter)
+
+                        comment = None
+                        continue
+                    
+                    elif current.value == 'TYPE':
+                        current = next(iter)
+                        while True:
+                            current, comment = skip(current)
+                            if current.type != Type.IDENTIFIER and current.type != Type.TYPE:
+                                break
+                            start = current.span.start
+                            name = current.value
+                            current = next(iter)
+
+                            export = False
+                            if current.value == '*':
+                                export = True
+                                current = next(iter)
+
+                            if current.type != Type.OPERATOR or current.value != '=':
+                                break
+                            isRecord = False
+                            current = next(iter)
+                            while True:
+                                if current.type == Type.KEYWORD:
+                                    if current.value == 'RECORD':
+                                        isRecord = True
+                                    elif current.value == 'END' and isRecord:
+                                        current = next(iter)
+                                        break
+                                elif current.type == Type.SEMI and not isRecord:
+                                    break
+                                current = next(iter)
+                            
+                            if export:
+                                module.entries.append(Entry(EntryType.TYPE, name, Span(start, current.span.end), None, None))
+                            current = next(iter)
+                        comment = None
+                        continue
+
+                    elif current.value == 'VAR':
+                        current = next(iter)
+                        while True:
+                            while current.type == Type.NEWLINE:
+                                current = next(iter)
+                            if current.type != Type.IDENTIFIER:
+                                break
+                            start = current.span.start
+                            name = current.value
+                            current = next(iter)
+                            if current.type != Type.OPERATOR or current.value != ':':
+                                break
+                            current = next(iter)
+                            while True:
+                                if current.type == Type.SEMI:
+                                    break
+                                current = next(iter)
+                            module.entries.append(Entry(EntryType.VAR, name, Span(start, current.span.end), None, None))
+                            current = next(iter)
+                        comment = None
+                        continue
+
+                    elif current.value == 'PROCEDURE':
+                        start = current.span.start
+                        current = next(iter)
+                        
+                        # Skip language definition
+                        if current.type == Type.LBRA:
+                            current = next(iter)
+                            while True:
+                                if current.type == Type.RBRA:
+                                    break
+                                current = next(iter)
+                            current = next(iter)
+                        
+                        # Receiver
+                        ref = None
+                        if current.type == Type.LPAR:
+                            current = next(iter)
+                            if current.type == Type.KEYWORD and current.value == "VAR":
+                                current = next(iter)
+
+                            if current.type != Type.IDENTIFIER:
+                                continue
+                            
+                            current = next(iter)
+                            if current.type != Type.OPERATOR or current.value != ':':
+                                continue
+                            
+                            current = next(iter)
+                            if current.type != Type.IDENTIFIER:
+                                continue
+                            ref = current.value
+
+                            current = next(iter)
+                            if current.type != Type.RPAR:
+                                continue
+                            current = next(iter)
+
+                        # Expect identifier
+                        if current.type != Type.IDENTIFIER:
+                            continue
+                        name = current.value
+                        current = next(iter)
+                        
+                        export = False
+                        if current.value == '*':
+                            export = True
+                            current = next(iter)
+                        
+                        # Skip argument definition if exists
+                        if current.type == Type.LPAR:
+                            while True:
+                                if current.type == Type.RPAR:
+                                    break;
+                                current = next(iter)
+
+                        # Procedure end with semicolon
+                        while True:
+                            if current.type == Type.SEMI:
+                                break;
+                            current = next(iter)
+                        current = next(iter)
+                        end = current.span.end
+
+                        # Check if EXTERN
+                        if current.value == 'EXTERN':
+                            current = next(iter)
+                            if current.type == Type.SEMI:
+                                current = next(iter)
+                            if export:
+                                module.entries.append(Entry(EntryType.PROCEDURE, name, Span(start, end), comment, ref))
+                                comment = None
+                        else:
+                            while True:
+                                # Search for matching end
+                                if current.type == Type.KEYWORD and current.value == 'END':
+                                    current = next(iter)
+                                    if current.type == Type.IDENTIFIER and current.value == name:
+                                        current = next(iter)
+                                        if current.type == Type.SEMI:
+                                            current = next(iter)
+                                        if export:
+                                            module.entries.append(Entry(EntryType.PROCEDURE, name, Span(start, end), comment, ref))
+                                        comment = None
+                                        current = next(iter)
+                                        break
+                                current = next(iter)
+            current = next(iter)
+    except StopIteration:
+        pass
+    
+    try:
+        current = next(iter)
+        if current.type == Type.DSTART:
+            while current.type != Type.DEND:
+                current = next(iter)
+            current = next(iter)
+    except StopIteration:
+        pass
+
+    return module, current.span.end
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("inputfile")
+    parser.add_argument("-o", "--output", type=str, default = '')
+    args = parser.parse_args()
+    st = open(args.inputfile).read()
+
+    if not args.output:
+        fh = sys.stdout
+    else:
+        print(args.output)
+        fh = open(args.output, 'w')
+    
+    def ref(module, ref, name):
+        if not ref:
+            print('.. _%s.%s:' % (module, name), file = fh)
+        else:
+            print('.. _%s.%s.%s:' % (module, ref, name), file = fh)
+        print(file = fh)
+
+    def heading(title, ch = '=', overline = False):
+        if overline : print(ch * len(title), file = fh)
+        print(title, file = fh)
+        print(ch * len(title), file = fh)
+        print(file = fh)
+    
+    def comment(span):
+        print(st[span.start:span.end].strip().lstrip('(*').rstrip('*)'), file = fh)
+        print(file = fh)
+
+    def code(span):
+        print('.. code-block:: modula2', file = fh)
+        print(file = fh)
+        for line in st[span.start:span.end].splitlines():
+            print('    ' + line, file = fh)
+        print(file = fh)
+    
+    module, end = parse(st)
+    epilog = st[end:].strip()
+
+    def filtered(type):
+        return tuple(filter(lambda item : item.type == type, module.entries))
+
+    # Index & Reference
+    print('.. index::', file = fh)
+    print('    single: %s' % module.name, file = fh)
+    print(file = fh)
+
+    print('.. _%s:' % module.name, file = fh)
+    print(file = fh)
+
+    # Heading
+    heading("%s" % module.name, '*', True)
+    if not module.doc is None:
+        comment(module.doc.span)
+
+    # Const
+    const = filtered(EntryType.CONST)
+    if const:
+        heading("Const", '=')
+        for item in const:
+            code(item.span)
+            
+    # Types
+    type = filtered(EntryType.TYPE)
+    if type:
+        heading("Types", '=')
+        for item in type:
+            code(item.span)
+    
+    # Vars
+    var = filtered(EntryType.VAR)
+    if var:
+        heading("Vars", '=')
+        for item in var:
+            code(item.span)
+
+    # Procedures
+    proc = filtered(EntryType.PROCEDURE)
+    if proc:
+        heading("Procedures", '=')
+        for item in proc:
+            ref(module.name, item.ref, item.name)
+            if item.ref:
+                heading("%s.%s" % (item.ref, item.name), '-')
+            else:
+                heading(item.name, '-')
+
+            if not item.doc is None:
+                comment(item.doc.span)
+            code(item.span)
+    
+    # Possibly add epilog as example
+    if len(epilog):
+        print(file = fh)
+        heading("Example", '=')
+        print(epilog, file = fh)
+        print(file = fh)
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add basic support for inline API documentation  in Oberon modules.

Comments starting with (** is exported to documentation.

This is a simple python script which should probably be replaced by the C++ parser wrapped in a simple tool at a later stage.