### PR TITLE
Initial version of type size agnostic changes [DEAFT]

### DIFF
--- a/src/codegen/llvm/LLVMIRBuilder.h
+++ b/src/codegen/llvm/LLVMIRBuilder.h
@@ -87,10 +87,10 @@ private:
     Value *createPackCall(Value *, Value *);
     Value *createUnpkCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createExitCall(Value *);
-    Value *createExclCall(Value *, Value *);
+    Value *createExclCall(TypeNode *, Value *, Value *);
     Value *createDisposeCall(TypeNode *, Value *);
     Value *createIncDecCall(ProcKind, vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
-    Value *createInclCall(Value *, Value *);
+    Value *createInclCall(TypeNode *, Value *, Value *);
     Value *createLenCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);
     Value *createLongCall(ExpressionNode *, Value *);
     Value *createLslCall(vector<unique_ptr<ExpressionNode>> &, std::vector<Value *> &);

--- a/src/data/ast/ExpressionNode.cpp
+++ b/src/data/ast/ExpressionNode.cpp
@@ -308,7 +308,7 @@ void NilLiteralNode::print(std::ostream &stream) const {
 }
 
 
-bitset<32> SetLiteralNode::value() const {
+bitset<64> SetLiteralNode::value() const {
     return value_;
 }
 
@@ -321,7 +321,7 @@ void SetLiteralNode::accept(NodeVisitor &visitor) {
 }
 
 
-bitset<32> RangeLiteralNode::value() const {
+bitset<64> RangeLiteralNode::value() const {
     return value_;
 }
 

--- a/src/data/ast/ExpressionNode.h
+++ b/src/data/ast/ExpressionNode.h
@@ -287,13 +287,13 @@ public:
 class SetLiteralNode final : public LiteralNode {
 
 private:
-    bitset<32> value_;
+    bitset<64> value_;
 
 public:
-    SetLiteralNode(const FilePos &pos, bitset<32> value, TypeNode *type = nullptr, TypeNode *cast = nullptr) :
+    SetLiteralNode(const FilePos &pos, bitset<64> value, TypeNode *type = nullptr, TypeNode *cast = nullptr) :
             LiteralNode(NodeType::set, pos, TypeKind::SET, type, cast), value_(value) {};
 
-    [[nodiscard]] bitset<32> value() const;
+    [[nodiscard]] bitset<64> value() const;
 
     void accept(NodeVisitor &visitor) final;
     void print(std::ostream &stream) const final;
@@ -304,16 +304,16 @@ public:
 class RangeLiteralNode final : public LiteralNode {
 
 private:
-    bitset<32> value_;
+    bitset<64> value_;
     int64_t lower_;
     int64_t upper_;
 
 public:
-    RangeLiteralNode(const FilePos &pos, bitset<32> value, int64_t lower, int64_t upper,
+    RangeLiteralNode(const FilePos &pos, bitset<64> value, int64_t lower, int64_t upper,
                      TypeNode *type = nullptr, TypeNode *cast = nullptr) :
             LiteralNode(NodeType::range, pos, TypeKind::SET, type, cast), value_(value), lower_(lower), upper_(upper) {};
 
-    [[nodiscard]] bitset<32> value() const;
+    [[nodiscard]] bitset<64> value() const;
     [[nodiscard]] int64_t lower() const;
     [[nodiscard]] int64_t upper() const;
 

--- a/src/data/symtab/SymbolImporter.cpp
+++ b/src/data/symtab/SymbolImporter.cpp
@@ -108,7 +108,7 @@ void SymbolImporter::readDeclaration(SymbolFile *file, NodeType nodeType, Module
                     expr = make_unique<RealLiteralNode>(EMPTY_POS, file->readDouble(), type);
                     break;
                 case TypeKind::SET:
-                    expr = make_unique<SetLiteralNode>(EMPTY_POS, bitset<32>(static_cast<unsigned>(file->readInt())), type);
+                    expr = make_unique<SetLiteralNode>(EMPTY_POS, bitset<64>(static_cast<unsigned>(file->readInt())), type);
                     break;
                 default:
                     logger_.error(file->path(), "Cannot import constant " + name + ".");

--- a/src/sema/Sema.h
+++ b/src/sema/Sema.h
@@ -70,7 +70,7 @@ private:
     uint8_t foldChar(const FilePos &, const FilePos &, ExpressionNode *);
     double foldReal(const FilePos &, const FilePos &, ExpressionNode *);
     string foldString(const FilePos &, const FilePos &, ExpressionNode *);
-    bitset<32> foldSet(const FilePos &, const FilePos &, ExpressionNode *);
+    bitset<64> foldSet(const FilePos &, const FilePos &, ExpressionNode *);
     unique_ptr<LiteralNode> fold(const FilePos &, const FilePos &, ExpressionNode *);
     unique_ptr<LiteralNode> fold(const FilePos &, const FilePos &,
                                  OperatorType, ExpressionNode *);
@@ -181,7 +181,7 @@ public:
     unique_ptr<StringLiteralNode> onStringLiteral(const FilePos &, const FilePos &, const string &);
     unique_ptr<CharLiteralNode> onCharLiteral(const FilePos &, const FilePos &, uint8_t);
     unique_ptr<NilLiteralNode> onNilLiteral(const FilePos &, const FilePos &);
-    unique_ptr<SetLiteralNode> onSetLiteral(const FilePos &, const FilePos &, bitset<32>);
+    unique_ptr<SetLiteralNode> onSetLiteral(const FilePos &, const FilePos &, bitset<64>);
 
     bool isDefined(Ident *);
     bool isConstant(QualIdent *);


### PR DESCRIPTION
This PR contains changed to allow avoid hard coded sizes in the backend.
These changes are needed in order to later support cross compiling to target with different sizes than
currently hard coded into the compiler.

This is marked [DRAFT] as I request comments to these changes:
* Currently the integer literal types are hard coded in the scanner. Here it should perhaps just check if it fits 64bit integer and then move the logic for detecting sizes to sema?
* Not sure how to update the symbol files. Should we change to use fixed sizes here (int8, int16, int32 and int64)? 
* I am not to familiar with the part of the code touched here, so I might have overlooked issues to look out for.

With these changes the unittests pass with the same results as earlier.
Some simple test of different sizes of SET and LONGINT works as expected.
