### PR TITLE
Code Review of Scanner Implementation

### DIFF
--- a/lib/include/global.h
+++ b/lib/include/global.h
@@ -32,18 +32,18 @@ struct SourceLoc {
     SourcePos start, end;
 };
 
-static const FilePos EMPTY_POS = {"", 0, 0, 0 };
-static const SourceLoc EMPTY_LOC = {"", {0, 0, 0}, {0, 0, 0}};
+inline const FilePos EMPTY_POS = {"", 0, 0, 0 };
+inline const SourceLoc EMPTY_LOC = {"", {0, 0, 0}, {0, 0, 0}};
 
 template <typename T>
-static std::string to_string(T obj) {
+inline std::string to_string(T obj) {
     std::stringstream stream;
     stream << obj;
     return stream.str();
 }
 
 template <typename T>
-static std::string to_string(T *obj) {
+inline std::string to_string(T *obj) {
     std::stringstream stream;
     stream << *obj;
     return stream.str();

--- a/lib/scanner/Scanner.cpp
+++ b/lib/scanner/Scanner.cpp
@@ -11,29 +11,34 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/convert.hpp>
-#include <boost/convert/stream.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/convert/stream.hpp>
 
 #include "IdentToken.h"
 #include "LiteralToken.h"
 #include "UndefinedToken.h"
 
+using std::filesystem::path;
 using std::make_unique;
+using std::queue;
+using std::streampos;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
 
-Scanner::Scanner(Logger &logger, const path &path) :
-        logger_(logger), path_(path), lineNo_(1), charNo_(0), ch_{}, eof_(false) {
+ScannerError::~ScannerError() = default;
+
+Scanner::Scanner(Logger &logger, path path) :
+        logger_(logger), path_(std::move(path)), lineNo_(1), charNo_(0), ch_{}, eof_(false) {
     init();
     file_.open(path_.string(), std::ifstream::binary);
     if (!file_.is_open()) {
         logger_.error(string(), "cannot open file: " + path_.string() + ".");
-        exit(1);
+        throw ScannerError();
     }
     read();
 }
@@ -66,17 +71,20 @@ void Scanner::init() {
                   { "TRUE", TokenType::boolean_literal}, { "FALSE", TokenType::boolean_literal } };
 }
 
-const Token* Scanner::peek(const bool advance) {
+const Token* Scanner::peek() {
     if (tokens_.empty()) {
         tokens_.push(scanToken());
-        return tokens_.back().get();
-    }
-    if (advance) {
-        const auto token = tokens_.back().get();
-        tokens_.push(scanToken());
-        return token;
     }
     return tokens_.front().get();
+}
+
+const Token* Scanner::peekAhead() {
+    if (tokens_.empty()) {
+        tokens_.push(scanToken());
+    }
+    const auto token = tokens_.back().get();
+    tokens_.push(scanToken());
+    return token;
 }
 
 unique_ptr<const Token> Scanner::next() {
@@ -89,25 +97,27 @@ unique_ptr<const Token> Scanner::next() {
 }
 
 void Scanner::seek(const FilePos &pos) {
+    file_.clear();
     file_.seekg(pos.offset - static_cast<streampos>(1));
     queue<unique_ptr<const Token>> empty;
     std::swap(tokens_, empty);
     lineNo_ = pos.lineNo;
     charNo_ = pos.charNo - 1;
-    ch_ = '\0';
+    eof_ = false;
+    read();
 }
 
 unique_ptr<const Token> Scanner::scanToken() {
     // skip whitespace
-    while (!eof_ && std::isspace(ch_)) {
+    while (!eof_ && std::isspace(static_cast<unsigned char>(ch_))) {
         read();
     }
     FilePos pos = current();
     if (!eof_) {
-        if (std::isalpha(ch_) || ch_ == '_') {
+        if (std::isalpha(static_cast<unsigned char>(ch_)) || ch_ == '_') {
             return scanIdent();
         }
-        if (std::isdigit(ch_)) {
+        if (std::isdigit(static_cast<unsigned char>(ch_))) {
             return scanNumber();
         }
         if (ch_ == '"') {
@@ -168,7 +178,6 @@ unique_ptr<const Token> Scanner::scanToken() {
             case '.':
                 read();
                 if (!eof_ && ch_ == '.') {
-                    FilePos nextPos = current();
                     read();
                     if (!eof_ && ch_ == '.') {
                         read();
@@ -230,7 +239,7 @@ void Scanner::read() {
         eof_ = true;
     } else {
         logger_.error(path_.string(), "error reading file.");
-        exit(1);
+        throw ScannerError();
     }
 
 }
@@ -249,10 +258,14 @@ void Scanner::scanComment(const FilePos &pos) {
     while (true) {
         while (true) {
             while (ch_ == '(') {
-                auto npos = current();
+                auto nextPos = current();
                 read();
+                if (eof_) {
+                    logger_.error(pos, "comment not closed.");
+                    throw ScannerError();
+                }
                 if (ch_ == '*') {
-                    scanComment(npos);
+                    scanComment(nextPos);
                 }
             }
             if (ch_ == '*') {
@@ -261,7 +274,7 @@ void Scanner::scanComment(const FilePos &pos) {
             }
             if (eof_) {
                 logger_.error(pos, "comment not closed.");
-                exit(1);
+                throw ScannerError();
             }
             read();
         }
@@ -271,7 +284,7 @@ void Scanner::scanComment(const FilePos &pos) {
         }
         if (eof_) {
             logger_.error(pos, "comment not closed.");
-            exit(1);
+            throw ScannerError();
         }
     }
 }
@@ -282,7 +295,7 @@ unique_ptr<const Token> Scanner::scanIdent() {
     do {
         ss << ch_;
         read();
-    } while (!eof_ && (std::isalnum(ch_) || ch_ == '_'));
+    } while (!eof_ && (std::isalnum(static_cast<unsigned char>(ch_)) || ch_ == '_'));
     std::string ident = ss.str();
     if (const auto it = keywords_.find(ident); it != keywords_.end()) {
         if (it->second == TokenType::boolean_literal) {
@@ -299,7 +312,8 @@ unique_ptr<const Token> Scanner::scanNumber() {
     bool isChar = false;
     FilePos pos = current();
     std::stringstream ss;
-    while (!eof_ && ((ch_ >= '0' && ch_ <= '9') || (std::toupper(ch_) >= 'A' && std::toupper(ch_) <= 'F'))) {
+    while (!eof_ && ((ch_ >= '0' && ch_ <= '9') ||
+        (std::toupper(static_cast<unsigned char>(ch_)) >= 'A' && std::toupper(static_cast<unsigned char>(ch_)) <= 'F'))) {
         ss << ch_;
         read();
         if (ch_ == '.') {
@@ -307,6 +321,7 @@ unique_ptr<const Token> Scanner::scanNumber() {
             read();
             if (ch_ == '.') {
                 file_.seekg(offset);
+                charNo_--;
                 break;
             }
             ss << '.';
@@ -418,13 +433,19 @@ unique_ptr<const Token> Scanner::scanString() {
     stringstream ss;
     auto pos = current();
     read();
-    while (ch_ != '"') {
+    while (!eof_ && ch_ != '"') {
         ss << ch_;
         if (ch_ == '\\') {
             read();
-            ss << ch_;
+            if (!eof_) {
+                ss << ch_;
+            }
         }
         read();
+    }
+    if (eof_) {
+        logger_.error(pos, "string literal not terminated.");
+        throw ScannerError();
     }
     read();
     string str = unescape(ss.str());
@@ -435,34 +456,54 @@ unique_ptr<const Token> Scanner::scanString() {
     return make_unique<StringLiteralToken>(pos, current(), str);
 }
 
-std::string Scanner::escape(std::string str) {
-    boost::replace_all(str, "\0", "\\0");
-    boost::replace_all(str, "\'", "\\'");
-    boost::replace_all(str, "\"", "\\\"");
-    boost::replace_all(str, "\?", "\\?");
-    boost::replace_all(str, "\\", "\\\\");
-    boost::replace_all(str, "\a", "\\a");
-    boost::replace_all(str, "\b", "\\b");
-    boost::replace_all(str, "\f", "\\f");
-    boost::replace_all(str, "\n",  "\\n");
-    boost::replace_all(str, "\r", "\\r");
-    boost::replace_all(str, "\t", "\\t");
-    boost::replace_all(str, "\v", "\\v");
-    return str;
+std::string Scanner::escape(const std::string& str) {
+    std::string result;
+    result.reserve(str.size() * 2);
+    for (const char c : str) {
+        switch (c) {
+            case '\0': result += "\\0";  break;
+            case '\'': result += "\\'";  break;
+            case '"':  result += "\\\""; break;
+            case '?':  result += "\\?";  break;
+            case '\\': result += "\\\\"; break;
+            case '\a': result += "\\a";  break;
+            case '\b': result += "\\b";  break;
+            case '\f': result += "\\f";  break;
+            case '\n': result += "\\n";  break;
+            case '\r': result += "\\r";  break;
+            case '\t': result += "\\t";  break;
+            case '\v': result += "\\v";  break;
+            default:   result += c;      break;
+        }
+    }
+    return result;
 }
 
-std::string Scanner::unescape(std::string str) {
-    boost::replace_all(str, "\\0", "\0");
-    boost::replace_all(str, "\\'", "\'");
-    boost::replace_all(str, "\\\"", "\"");
-    boost::replace_all(str, "\\?", "\?");
-    boost::replace_all(str, "\\\\", "\\");
-    boost::replace_all(str, "\\a", "\a");
-    boost::replace_all(str, "\\b", "\b");
-    boost::replace_all(str, "\\f", "\f");
-    boost::replace_all(str, "\\n",  "\n");
-    boost::replace_all(str, "\\r", "\r");
-    boost::replace_all(str, "\\t", "\t");
-    boost::replace_all(str, "\\v", "\v");
-    return str;
+std::string Scanner::unescape(const std::string &str) {
+    std::string result;
+    result.reserve(str.size());
+    size_t i = 0;
+    while (i < str.size()) {
+        if (str[i] == '\\' && i + 1 < str.size()) {
+            switch (str[i + 1]) {
+                case '0':  result += '\0'; break;
+                case '\'': result += '\''; break;
+                case '"':  result += '"';  break;
+                case '?':  result += '?';  break;
+                case '\\': result += '\\'; break;
+                case 'a':  result += '\a'; break;
+                case 'b':  result += '\b'; break;
+                case 'f':  result += '\f'; break;
+                case 'n':  result += '\n'; break;
+                case 'r':  result += '\r'; break;
+                case 't':  result += '\t'; break;
+                case 'v':  result += '\v'; break;
+                default:   result += str[i]; i++; continue;
+            }
+            i += 2;
+        } else {
+            result += str[i++];
+        }
+    }
+    return result;
 }

--- a/lib/scanner/Scanner.h
+++ b/lib/scanner/Scanner.h
@@ -8,6 +8,7 @@
 #define OBERON_LANG_SCANNER_H
 
 
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -19,44 +20,118 @@
 #include "Logger.h"
 #include "Token.h"
 
-using std::filesystem::path;
-using std::ifstream;
-using std::queue;
-using std::streampos;
-using std::string;
-using std::unique_ptr;
-using std::unordered_map;
+/**
+ * @brief Tag exception thrown by the scanner on unrecoverable errors.
+ *
+ * Thrown after the error has already been recorded via the @c Logger, so
+ * callers only need to catch this type to terminate cleanly — no additional
+ * message is required.
+ */
+struct ScannerError : std::exception {
+    ~ScannerError() override;
+};
 
+/**
+ * @brief Handwritten scanner (lexer) for the Oberon programming language.
+ *
+ * Reads a source file character by character and produces a stream of typed
+ * @c Token objects.  Identifiers are matched against a keyword table so that
+ * reserved words are returned as their own token types.  Numeric, character,
+ * and string literals are fully evaluated during scanning.
+ *
+ * The scanner supports arbitrary lookahead through an internal token buffer:
+ * @c peek() and @c peekAhead() inspect tokens without consuming them, while
+ * @c next() removes and returns the next token from the stream.
+ *
+ * On unrecoverable errors (file not found, I/O failure, unterminated literal
+ * or comment) the scanner logs a diagnostic and throws @c ScannerError.
+ */
 class Scanner {
 
 public:
-    Scanner(Logger &, const path &);
-    ~Scanner();
-    const Token* peek(bool = false);
-    unique_ptr<const Token> next();
-    void seek(const FilePos &);
+    /**
+     * @brief Opens @p path and primes the scanner by reading the first character.
+     * @param logger  Diagnostic sink used for all error and warning messages.
+     * @param path    Path to the Oberon source file to scan.
+     * @throws ScannerError if the file cannot be opened.
+     */
+    Scanner(Logger &logger, std::filesystem::path path);
 
-    static string escape(string str);
-    static string unescape(string str);
+    /** @brief Closes the source file. */
+    ~Scanner();
+
+    /**
+     * @brief Returns the next token without consuming it.
+     *
+     * Scans one token if the lookahead buffer is empty.  Repeated calls
+     * return the same token until @c next() is called.
+     *
+     * @return Non-owning pointer to the next token; valid until @c next() is called.
+     */
+    const Token* peek();
+
+    /**
+     * @brief Extends the lookahead buffer by one token and returns the previous end.
+     *
+     * Useful when the parser needs to inspect two tokens ahead without consuming
+     * either.  After this call, @c peek() still returns the same front-of-buffer
+     * token, but the buffer now also contains the token that follows it.
+     *
+     * @return Non-owning pointer to the token that was at the back of the buffer
+     *         before the new token was scanned; valid until @c next() is called.
+     */
+    const Token* peekAhead();
+
+    /**
+     * @brief Removes and returns the next token from the stream.
+     * @return Owning pointer to the consumed token.
+     */
+    std::unique_ptr<const Token> next();
+
+    /**
+     * @brief Escapes special characters in @p str using C-style backslash sequences.
+     *
+     * For example, a newline byte becomes the two-character sequence @c \\n.
+     * This is the inverse of @c unescape().
+     *
+     * @param str  String whose special characters are to be escaped.
+     * @return A new string with all special characters replaced by escape sequences.
+     */
+    static std::string escape(const string &str);
+
+    /**
+     * @brief Replaces C-style backslash escape sequences in @p str with their
+     *        corresponding characters.
+     *
+     * Processes the string left-to-right so that sequences such as @c \\\\n
+     * are handled correctly: @c \\\\ becomes a single backslash, and the
+     * following @c n remains a literal character.  This is the inverse of
+     * @c escape().
+     *
+     * @param str  String containing backslash escape sequences.
+     * @return A new string with all recognized escape sequences substituted.
+     */
+    static std::string unescape(const string &str);
 
 private:
     Logger &logger_;
-    const path &path_;
-    queue<unique_ptr<const Token>> tokens_;
+    std::filesystem::path path_;
+    std::queue<std::unique_ptr<const Token>> tokens_;
     int lineNo_, charNo_;
     char ch_;
     bool eof_;
-    unordered_map<string, TokenType> keywords_;
-    ifstream file_;
+    std::unordered_map<std::string, TokenType> keywords_;
+    std::ifstream file_;
 
     void init();
     void read();
+    void seek(const FilePos &);
     FilePos current();
-    unique_ptr<const Token> scanToken();
-    unique_ptr<const Token> scanIdent();
-    unique_ptr<const Token> scanNumber();
-    // unique_ptr<const Token> scanCharacter();
-    unique_ptr<const Token> scanString();
+    std::unique_ptr<const Token> scanToken();
+    std::unique_ptr<const Token> scanIdent();
+    std::unique_ptr<const Token> scanNumber();
+    // std::unique_ptr<const Token> scanCharacter();
+    std::unique_ptr<const Token> scanString();
     void scanComment(const FilePos &);
 
 };

--- a/lib/scanner/Token.cpp
+++ b/lib/scanner/Token.cpp
@@ -94,6 +94,7 @@ std::ostream& operator<<(std::ostream &stream, const TokenType &type) {
         case TokenType::kw_with: result = "WITH"; break;
         case TokenType::kw_array: result = "ARRAY"; break;
         case TokenType::kw_record: result = "RECORD"; break;
+        case TokenType::kw_pointer: result = "POINTER"; break;
         case TokenType::kw_const: result = "CONST"; break;
         case TokenType::kw_type: result = "TYPE"; break;
         case TokenType::kw_var: result = "VAR"; break;

--- a/lib/scanner/Token.h
+++ b/lib/scanner/Token.h
@@ -11,7 +11,7 @@
 #include "global.h"
 #include <ostream>
 
-enum class TokenType : char {
+enum class TokenType {
     eof, undef,
     boolean_literal, byte_literal, char_literal,
     short_literal, int_literal, long_literal,

--- a/lib/scanner/UndefinedToken.cpp
+++ b/lib/scanner/UndefinedToken.cpp
@@ -6,7 +6,7 @@
 
 #include "UndefinedToken.h"
 
-char UndefinedToken::value() {
+char UndefinedToken::value() const {
     return value_;
 }
 

--- a/lib/scanner/UndefinedToken.h
+++ b/lib/scanner/UndefinedToken.h
@@ -17,7 +17,7 @@ public:
             Token(TokenType::undef, pos), value_(value) { };
     ~UndefinedToken() override = default;
 
-    [[nodiscard]] char value();
+    [[nodiscard]] char value() const;
 
     void print(std::ostream &stream) const override;
 

--- a/olang/main.cpp
+++ b/olang/main.cpp
@@ -16,6 +16,7 @@
 #include "codegen/CodeGenFactory.h"
 #include "compiler/Compiler.h"
 #include "compiler/CompilerConfig.h"
+#include "scanner/Scanner.h"
 
 // For certain modules, LLVM emits stack protection functionality under Windows that
 // involves calls to the standard runtime of the target platform. Since these libraries 
@@ -135,6 +136,7 @@ int main(const int argc, const char **argv) {
             return EXIT_FAILURE;
         }
         vector<fs::path>& inputs = config.getInputFiles();
+        try {
         if (config.isJit()) {
 #ifndef _LLVM_LEGACY
             if (inputs.size() != 1) {
@@ -151,6 +153,9 @@ int main(const int argc, const char **argv) {
         for (auto &input : inputs) {
             logger.debug("Compiling module " + to_string(input) + ".");
             compiler.compile(input);
+        }
+        } catch (const ScannerError &) {
+            return EXIT_FAILURE;
         }
         string status = logger.getErrorCount() == 0 ? "complete" : "failed";
         logger.info("Compilation " + status + ": " +

--- a/test/unittests/scanner/StringEscape.Mod
+++ b/test/unittests/scanner/StringEscape.Mod
@@ -1,0 +1,12 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE StringEscape;
+IMPORT Out;
+
+BEGIN
+  Out.String("\\n"); Out.Ln
+END StringEscape.
+(*
+  CHECK: \n
+*)

--- a/test/unittests/scanner/StringNullByte.Mod
+++ b/test/unittests/scanner/StringNullByte.Mod
@@ -1,0 +1,15 @@
+(*
+  RUN: %oberon -I "%S%{pathsep}%inc" -L "%S%{pathsep}%lib" -l oberon --run %s | filecheck %s
+*)
+MODULE StringNullByte;
+IMPORT Out;
+
+VAR s: ARRAY 8 OF CHAR;
+
+BEGIN
+  s := "a\0b";
+  Out.Int(ORD(s[1]), 0); Out.Ln
+END StringNullByte.
+(*
+  CHECK: 0
+*)

--- a/test/unittests/scanner/UnterminatedString.Mod
+++ b/test/unittests/scanner/UnterminatedString.Mod
@@ -1,0 +1,11 @@
+(*
+  RUN: not %oberon --run %s 2>&1 | filecheck %s
+*)
+MODULE UnterminatedString;
+
+CONST s = "unterminated string literal;
+
+END UnterminatedString.
+(*
+  CHECK: {{.*}}:6:11:{{.*}}error:{{.*}}string literal not terminated.
+*)

--- a/utils/grammar/main.cpp
+++ b/utils/grammar/main.cpp
@@ -11,6 +11,7 @@
 
 #include <config.h>
 #include "Loader.h"
+#include "Scanner.h"
 #include "Validator.h"
 
 namespace fs = std::filesystem;
@@ -24,7 +25,12 @@ int main(const int argc, const char *argv[]) {
         exit(1);
     }
     Loader loader(logger, path(argv[1]));
-    auto grammar = loader.load();
+    std::unique_ptr<Grammar> grammar;
+    try {
+        grammar = loader.load();
+    } catch (const ScannerError &) {
+        return EXIT_FAILURE;
+    }
     std::cout << *grammar << std::endl;
 
     Validator util(grammar.get());


### PR DESCRIPTION
  ### Bug Fixes
  - `scanString()`: added EOF guard to prevent infinite loop on unterminated string literals
  - `scanString()`: replaced `boost::replace_all`-based `unescape()` with a character-by-character loop, fixing incorrect handling of sequences such as `\\n` and silent deletion of `\0`
  - `escape()`: same rewrite to fix ordering bug where introduced backslashes were doubled
  - `scanComment()`: added missing EOF guard in innermost `while (ch_ == '(')` loop
  - `scanNumber()`: added `charNo_--` after `seekg` to fix source-position tracking for `..`

  ### Error Handling
  - Replaced all `exit(1)` calls in the scanner with `throw ScannerError()`
  - Added `ScannerError` tag-type exception (`struct ScannerError : std::exception`) to `Scanner.h`
  - Added `catch (const ScannerError &)` at the top level in `olang/main.cpp` and `utils/grammar/main.cpp`

  ### API Improvements
  - Split `peek(bool advance = false)` into `peek()` and `peekAhead()` for clarity
  - Fixed `seek()`: added `file_.clear()`, reset `eof_`, and replaced `ch_ = '\0'` with `read()`; made private
  - Changed `path_` from `const path &` (dangling reference risk) to a value type; constructor now takes by value and moves

  ### Code Quality
  - Removed namespace-level `using` directives from `Scanner.h`; moved required ones to `Scanner.cpp`
  - Added `static_cast<unsigned char>` to all `<cctype>` call sites to eliminate undefined behaviour on non-ASCII input
  - Dropped `TokenType : char` underlying type in favour of the default `int`
  - Changed `EMPTY_POS`, `EMPTY_LOC`, and `to_string` templates in `global.h` from `static` to `inline`
  - Fixed missing `const` on `UndefinedToken::value()`

  ### Documentation
  - Added Doxygen-compatible doc comments to all public members of `Scanner.h`

  ### Tests
  - `test/unittests/scanner/UnterminatedString.Mod`: scanner terminates with an error on an unterminated string literal
  - `test/unittests/scanner/StringEscape.Mod`: `"\\n"` produces a two-character string, not a newline
  - `test/unittests/scanner/StringNullByte.Mod`: `\0` inside a string literal produces an embedded null byte